### PR TITLE
New connection way to different EC2 endpoints

### DIFF
--- a/Web/templates/systems/virtualmachines/overview.mako
+++ b/Web/templates/systems/virtualmachines/overview.mako
@@ -3,7 +3,7 @@
 <%inherit file="/diracPage.mako" />
 
 <%def name="head_tags()">
-${ h.javascript_link( "http://www.google.com/jsapi" ) }
+${ h.javascript_link( "https://www.google.com/jsapi" ) }
 ${ h.javascript_link( "/javascripts/systems/virtualmachines/vmInstanceInfoWindow.js" ) }
 ${ h.javascript_link( "/javascripts/systems/virtualmachines/vmOverview.js" ) }
 <style>

--- a/WorkloadManagementSystem/Agent/VirtualMachineMonitorAgent.py
+++ b/WorkloadManagementSystem/Agent/VirtualMachineMonitorAgent.py
@@ -26,12 +26,16 @@ class VirtualMachineMonitorAgent( AgentModule ):
 
   def getAmazonVMId( self ):
     try:
-      fd = urllib2.urlopen( "http://instance-data.ec2.internal/latest/meta-data/instance-id" )
-      iD = fd.read().strip()
-      fd.close()
-      return S_OK( iD )
-    except Exception, e:
+      fd = urllib2.urlopen("http://instance-data.ec2.internal/latest/meta-data/instance-id", timeout=30)
+    except urllib2.URLError:
+      print 'Can not connect to EC2 URL. Trying address 169.254.169.254 directly... '
+    try:
+      fd = urllib2.urlopen("http://169.254.169.254/latest/meta-data/instance-id", timeout=30)
+    except urllib2.URLError, e:
       return S_ERROR( "Could not retrieve amazon instance id: %s" % str( e ) )
+    iD = fd.read().strip()
+    fd.close()
+    return S_OK( iD )
 
   def getOcciVMId( self ):
     try:

--- a/WorkloadManagementSystem/Agent/VirtualMachineMonitorAgent.py
+++ b/WorkloadManagementSystem/Agent/VirtualMachineMonitorAgent.py
@@ -12,7 +12,7 @@ except:
   from md5 import md5
 
 # DIRAC
-from DIRAC                       import S_OK, S_ERROR, gConfig, rootPath
+from DIRAC                       import S_OK, S_ERROR, gLogger, gConfig, rootPath
 from DIRAC.Core.Base.AgentModule import AgentModule
 from DIRAC.Core.Utilities        import List, Network
 
@@ -28,7 +28,7 @@ class VirtualMachineMonitorAgent( AgentModule ):
     try:
       fd = urllib2.urlopen("http://instance-data.ec2.internal/latest/meta-data/instance-id", timeout=30)
     except urllib2.URLError:
-      print 'Can not connect to EC2 URL. Trying address 169.254.169.254 directly... '
+      gLogger.warn("Can not connect to EC2 URL. Trying address 169.254.169.254 directly...")
     try:
       fd = urllib2.urlopen("http://169.254.169.254/latest/meta-data/instance-id", timeout=30)
     except urllib2.URLError, e:


### PR DESCRIPTION
New connection way let us connect to other EC2 endpoints.
New params added to config are EndpointURL and optional RegionName
Example section in config:

```
CloudEndpoints
{
  EC2IFJ
  {
    driver = Amazon
    cloudDriver = Amazon
    vmPolicy = static
    vmStopPolicy = never
    maxEndpointInstances = 3
    AccessKey = xxx
    SecretKey = xxx
    EndpointURL = http://[endpoint_address]:[port]
  }
}
```
