### PR TITLE
FIX: Amazon

### DIFF
--- a/Resources/Cloud/AmazonDirector.py
+++ b/Resources/Cloud/AmazonDirector.py
@@ -4,7 +4,7 @@
 # Author : Ricardo Graciani
 ########################################################################
 
-from DIRAC import S_OK
+from DIRAC import S_OK, S_ERROR
 from VMDIRAC.Resources.Cloud.VMDirector                  import VMDirector
 from VMDIRAC.WorkloadManagementSystem.Client.AmazonImage import AmazonImage
 
@@ -33,7 +33,10 @@ class AmazonDirector( VMDirector ):
     """
       Real backend method to submit a new Instance of a given Image
     """
-    ami = AmazonImage( imageName )
+    try:
+      ami = AmazonImage( imageName )
+    except Exception:
+      return S_ERROR("Failed to connect to AWS")  
     result = ami.startNewInstances()
     if not result[ 'OK' ]:
       return result

--- a/Resources/Cloud/CloudDirector.py
+++ b/Resources/Cloud/CloudDirector.py
@@ -49,7 +49,10 @@ class CloudDirector( VMDirector ):
     driver = gConfig.getValue( "%s/%s/%s" % ( endpointsPath, endpoint, 'cloudDriver' ), "" )
 
     if driver == 'Amazon':
-      ami = AmazonImage( imageName, endpoint )
+      try:
+        ami = AmazonImage( imageName, endpoint )
+      except Exception:
+        return S_ERROR("Failed to connect to AWS")  
       result = ami.startNewInstances()
       if not result[ 'OK' ]:
         return result

--- a/WorkloadManagementSystem/Agent/VirtualMachineMonitorAgent.py
+++ b/WorkloadManagementSystem/Agent/VirtualMachineMonitorAgent.py
@@ -173,7 +173,7 @@ class VirtualMachineMonitorAgent( AgentModule ):
     self.log.info( "cloudDriver is %s" % self.cloudDriver )
     if self.cloudDriver == 'generic':
       result = self.getGenericVMId()
-    elif self.cloudDriver == 'Amazon':
+    elif self.cloudDriver == 'amazon':
       result = self.getAmazonVMId()
     elif (self.cloudDriver == 'occi-0.9' or self.cloudDriver == 'occi-0.8' or self.cloudDriver == 'rocci-1.1' ):
       result = self.getOcciVMId()

--- a/WorkloadManagementSystem/Agent/VirtualMachineMonitorAgent.py
+++ b/WorkloadManagementSystem/Agent/VirtualMachineMonitorAgent.py
@@ -173,7 +173,7 @@ class VirtualMachineMonitorAgent( AgentModule ):
     self.log.info( "cloudDriver is %s" % self.cloudDriver )
     if self.cloudDriver == 'generic':
       result = self.getGenericVMId()
-    elif self.cloudDriver == 'amazon':
+    elif self.cloudDriver == 'Amazon':
       result = self.getAmazonVMId()
     elif (self.cloudDriver == 'occi-0.9' or self.cloudDriver == 'occi-0.8' or self.cloudDriver == 'rocci-1.1' ):
       result = self.getOcciVMId()

--- a/WorkloadManagementSystem/Client/AmazonImage.py
+++ b/WorkloadManagementSystem/Client/AmazonImage.py
@@ -96,7 +96,7 @@ class AmazonImage:
     except Exception, e:
       self.__errorStatus = "Can't connect to EC2: " + str(e)
       self.log.error( self.__errorStatus )
-      return
+      raise
 
     #FIXME: we will never reach a point where __errorStatus has anything
     if not self.__errorStatus:

--- a/WorkloadManagementSystem/Client/AmazonImage.py
+++ b/WorkloadManagementSystem/Client/AmazonImage.py
@@ -222,7 +222,11 @@ class AmazonImage:
     """
     if type( instancesList ) in ( types.StringType, types.UnicodeType ):
       instancesList = [ instancesList ]
-    self.__conn.terminate_instances( instancesList )
+    try:
+      self.__conn.terminate_instances( instancesList )
+    except Exception, error:
+      return S_ERROR("Exception: %s" % str(error))
+    return S_OK()
 
   def getAllInstances( self ):
     """

--- a/WorkloadManagementSystem/Service/VirtualMachineManagerHandler.py
+++ b/WorkloadManagementSystem/Service/VirtualMachineManagerHandler.py
@@ -260,7 +260,7 @@ class VirtualMachineManagerHandler( RequestHandler ):
       
       result = nima.stopInstance( uniqueID, publicIP )
 
-    elif ( cloudDriver == 'Amazon' ):
+    elif ( cloudDriver == 'amazon' ):
       imageName = gVirtualMachineDB.getImageNameFromInstance( uniqueID )
       if not imageName[ 'OK' ]:
         self.__logResult( 'declareInstanceHalting getImageNameFromInstance: ', imageName )

--- a/WorkloadManagementSystem/Service/VirtualMachineManagerHandler.py
+++ b/WorkloadManagementSystem/Service/VirtualMachineManagerHandler.py
@@ -260,7 +260,7 @@ class VirtualMachineManagerHandler( RequestHandler ):
       
       result = nima.stopInstance( uniqueID, publicIP )
 
-    elif ( cloudDriver == 'amazon' ):
+    elif ( cloudDriver == 'Amazon' ):
       imageName = gVirtualMachineDB.getImageNameFromInstance( uniqueID )
       if not imageName[ 'OK' ]:
         self.__logResult( 'declareInstanceHalting getImageNameFromInstance: ', imageName )

--- a/WorkloadManagementSystem/Service/VirtualMachineManagerHandler.py
+++ b/WorkloadManagementSystem/Service/VirtualMachineManagerHandler.py
@@ -275,7 +275,7 @@ class VirtualMachineManagerHandler( RequestHandler ):
         gLogger.error("Failed to connect to AWS")
         pass
       if awsima:
-        result = awsima.stopInstances( [uniqueID] )
+        result = awsima.stopInstances( uniqueID )
 
 
     else:

--- a/WorkloadManagementSystem/Service/VirtualMachineManagerHandler.py
+++ b/WorkloadManagementSystem/Service/VirtualMachineManagerHandler.py
@@ -23,6 +23,8 @@ from DIRAC.Core.Utilities.ThreadScheduler import gThreadScheduler
 # VMDIRAC
 from VMDIRAC.WorkloadManagementSystem.Client.NovaImage    import NovaImage
 from VMDIRAC.WorkloadManagementSystem.Client.OcciImage    import OcciImage
+from VMDIRAC.WorkloadManagementSystem.Client.AmazonImage  import AmazonImage
+
 from VMDIRAC.WorkloadManagementSystem.DB.VirtualMachineDB import VirtualMachineDB
 from VMDIRAC.Security                                     import VmProperties
 
@@ -230,7 +232,7 @@ class VirtualMachineManagerHandler( RequestHandler ):
         return imageName
       imageName = imageName[ 'Value' ]
 
-      gLogger.info( 'Declare instance haltig:  %s, endpoint: %s imageName: %s' % (str(uniqueID),endpoint,imageName) )
+      gLogger.info( 'Declare instance halting:  %s, endpoint: %s imageName: %s' % (str(uniqueID),endpoint,imageName) )
       oima   = OcciImage( imageName, endpoint )
       connOcci = oima.connectOcci()
       if not connOcci[ 'OK' ]:
@@ -257,6 +259,24 @@ class VirtualMachineManagerHandler( RequestHandler ):
       publicIP = publicIP[ 'Value' ]
       
       result = nima.stopInstance( uniqueID, publicIP )
+
+    elif ( cloudDriver == 'amazon' ):
+      imageName = gVirtualMachineDB.getImageNameFromInstance( uniqueID )
+      if not imageName[ 'OK' ]:
+        self.__logResult( 'declareInstanceHalting getImageNameFromInstance: ', imageName )
+        return imageName
+      imageName = imageName[ 'Value' ]
+
+      gLogger.info( 'Declare instance halting:  %s, endpoint: %s imageName: %s' % (str(uniqueID),endpoint,imageName) )
+      awsima = None
+      try:
+        awsima = AmazonImage( imageName, endpoint )
+      except Exception:
+        gLogger.error("Failed to connect to AWS")
+        pass
+      if awsima:
+        result = awsima.stopInstances( [uniqueID] )
+
 
     else:
       gLogger.warn( 'Unexpected cloud driver:  %s' % cloudDriver )


### PR DESCRIPTION
- Properly terminate the instances that should halt
- use try/except clause for the connection, as the S_OK S_ERROR are no
  use in constructors
