### PR TITLE
BUGFIX: Endpoint should be shown in browse instances

### DIFF
--- a/WorkloadManagementSystem/Agent/VirtualMachineMonitorAgent.py
+++ b/WorkloadManagementSystem/Agent/VirtualMachineMonitorAgent.py
@@ -124,7 +124,7 @@ class VirtualMachineMonitorAgent( AgentModule ):
       setattr( self, varName, value )
 
     for csOption, csDefault, varName in ( 
-                                          ( "JobWrappersLocation", "/tmp/", "vmJobWrappersLocation" )
+                                          ( "JobWrappersLocation", "/tmp/", "vmJobWrappersLocation" ),
                                         ):
 
       path = "%s/%s" % ( imgPath, csOption )

--- a/WorkloadManagementSystem/DB/VirtualMachineDB.py
+++ b/WorkloadManagementSystem/DB/VirtualMachineDB.py
@@ -729,7 +729,7 @@ class VirtualMachineDB( DB ):
     #Main fields
     tables = ( "`vm_Images` AS img", "`vm_Instances` AS inst")
     imageFields = ( 'VMImageID', 'Name')
-    instanceFields = ( 'RunningPod', 'InstanceID', 'Name', 'UniqueID', 'VMImageID',
+    instanceFields = ( 'RunningPod', 'InstanceID', 'Endpoint', 'Name', 'UniqueID', 'VMImageID',
                        'Status', 'PublicIP', 'Status', 'ErrorMessage', 'LastUpdate', 'Load', 'Uptime', 'Jobs' )
 
     fields = [ 'img.%s' % f for f in imageFields ] + [ 'inst.%s' % f for f in instanceFields ]

--- a/WorkloadManagementSystem/private/bootstrap/EGI-Fedcloud-general-DIRAC.context.sh
+++ b/WorkloadManagementSystem/private/bootstrap/EGI-Fedcloud-general-DIRAC.context.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# dirac contextualization script for EGI FedCloud
+# dirac contextualization script 
 # To be run as root on VM
 #
 
@@ -26,7 +26,7 @@ submitPool=${9}
 cpuTime=${10}
 cloudDriver=${11}
 
-echo "Running EGI-Fedcloud-general-DIRAC-context.sh '<siteName>' '<vmStopPolicy>' '<putCertPath>' '<putKeyPath>' '<localVmRunJobAgent>' '<localVmRunVmMonitorAgent>' '<localVmRunVmUpdaterAgent>' '<localVmRunLogAgent>' '<submitPool>' '<cpuTime>' '<cloudDriver>'" >> /var/log/dirac-context-script.log 2>&1
+echo "Running dirac-contex.sh '<siteName>' '<vmStopPolicy>' '<putCertPath>' '<putKeyPath>' '<localVmRunJobAgent>' '<localVmRunVmMonitorAgent>' '<localVmRunVmUpdaterAgent>' '<localVmRunLogAgent>' '<submitPool>' '<cpuTime>' '<cloudDriver>'" >> /var/log/dirac-context-script.log 2>&1
 echo "1 $siteName" >> /var/log/dirac-context-script.log 2>&1
 echo "2 $vmStopPolicy" >> /var/log/dirac-context-script.log 2>&1
 echo "3 $putCertPath" >> /var/log/dirac-context-script.log 2>&1
@@ -40,7 +40,7 @@ echo "10 $cpuTime" >> /var/log/dirac-context-script.log 2>&1
 echo "11 $cloudDriver" >> /var/log/dirac-context-script.log 2>&1
 
 # dirac user:
-        /usr/sbin/useradd -d /opt/dirac dirac
+        /usr/sbin/useradd -m -d /opt/dirac dirac
 # To work wiht the cmvfs LB_LOGIN of LHCb:
         chmod g+w /root
         chown root:dirac /root


### PR DESCRIPTION
Previous deletion of Endpoint was missing an alternative to show Endpoint field at vm browsing.
Please, do not delete if not supporting an alternative to the functionality on the web vm browsing.
