### PR TITLE
Several bug fixes

### DIFF
--- a/VMDIRAC/Resources/Cloud/CloudEndpoint.py
+++ b/VMDIRAC/Resources/Cloud/CloudEndpoint.py
@@ -294,7 +294,8 @@ cloud_final_modules:
 
     for nvm in xrange( vmsToSubmit ):
       instanceID = makeGuid()[:8]
-      result = self.createInstance( instanceID )
+      createPublicIP = 'ipPool' in self.parameters
+      result = self.createInstance( instanceID, createPublicIP )
       if result['OK']:
         node, publicIP = result['Value']
         self.log.debug( 'Created VM instance %s/%s with publicIP %s' % ( node.id, instanceID, publicIP ) )
@@ -566,7 +567,6 @@ cloud_final_modules:
       result = self.deleteFloatingIP( publicIP, node )
       if not result['OK']:
         self.log.error( 'Failed in deleteFloatingIP:', result[ 'Message' ] )
-        return result
 
     # Destroy the VM instance
     if node is not None:

--- a/VMDIRAC/Resources/Cloud/CloudEndpoint.py
+++ b/VMDIRAC/Resources/Cloud/CloudEndpoint.py
@@ -423,6 +423,7 @@ cloud_final_modules:
         if result['OK']:
           publicIP = result['Value']
         else:
+          vmNode.destroy()
           return result
       except Exception as exc:
         self.log.debug( 'Failed to wait node running %s' % str(exc) )

--- a/VMDIRAC/WorkloadManagementSystem/Agent/CloudDirector.py
+++ b/VMDIRAC/WorkloadManagementSystem/Agent/CloudDirector.py
@@ -260,8 +260,8 @@ class CloudDirector( AgentModule ):
           self.imageDict[imageName]['Platform'] = platform
           self.imageDict[imageName]['MaxInstances'] = ceDict['MaxInstances']
           if not self.imageDict[imageName]['CE'].isValid():
-            self.log.fatal( 'Failed to instantiate CloudEndpoint for %s' % imageName )
-            return result
+            self.log.error( 'Failed to instantiate CloudEndpoint for %s' % imageName )
+            continue
 
           if site not in self.sites:
             self.sites.append( site )

--- a/VMDIRAC/WorkloadManagementSystem/Bootstrap/vm-bootstrap-functions
+++ b/VMDIRAC/WorkloadManagementSystem/Bootstrap/vm-bootstrap-functions
@@ -133,7 +133,7 @@ vm_dirac_install() {
 
   dirac-configure -ddd -S $setup -C $config_server \
                   -o /DIRAC/Extensions=VMDIRAC \
-                  -o /DIRAC/VirtualOrganization=vo \
+                  -o /DIRAC/VirtualOrganization=$vo \
                   -o /LocalSite/ReleaseProject=$release_project \
                   -o /LocalSite/ReleaseVersion=$release_version \
                   -o /LocalSite/VMID=$VM_UUID \

--- a/VMDIRAC/WorkloadManagementSystem/Bootstrap/vm-pilot
+++ b/VMDIRAC/WorkloadManagementSystem/Bootstrap/vm-pilot
@@ -82,7 +82,7 @@ cp $CONTEXTDIR/*.py .
 # Run the Pilot 2.0 script
 python dirac-pilot.py \
  --debug \
- --setup Dirac-Production \
+ --setup $SETUP \
  -r $VERSION \
  -l $PROJECT \
  -e VMDIRAC \

--- a/VMDIRAC/WorkloadManagementSystem/DB/VirtualMachineDB.py
+++ b/VMDIRAC/WorkloadManagementSystem/DB/VirtualMachineDB.py
@@ -86,7 +86,7 @@ class VirtualMachineDB( DB ):
   tablesDesc[ 'vm_Instances' ] = { 'Fields' : { 'InstanceID' : 'BIGINT UNSIGNED AUTO_INCREMENT NOT NULL',
                                                 'RunningPod' : 'VARCHAR(255) NOT NULL',
                                                 'Name' : 'VARCHAR(255) NOT NULL',
-                                                'Endpoint' : 'VARCHAR(32) NOT NULL',
+                                                'Endpoint' : 'VARCHAR(255) NOT NULL',
                                                 'UniqueID' : 'VARCHAR(255) NOT NULL DEFAULT ""',
                                                 'VMImageID' : 'INTEGER UNSIGNED NOT NULL',
                                                 'Status' : 'VARCHAR(32) NOT NULL',

--- a/VMDIRAC/WorkloadManagementSystem/DB/VirtualMachineDB.py
+++ b/VMDIRAC/WorkloadManagementSystem/DB/VirtualMachineDB.py
@@ -1111,7 +1111,7 @@ class VirtualMachineDB( DB ):
       return instance
 
     if 'lastRowId' in instance:
-      self.__addInstanceHistory( instance[ 'lastRowId' ], validStates[ 0 ] )
+      self.__addInstanceHistory( instance[ 'lastRowId' ], status )
       return S_OK( instance[ 'lastRowId' ] )
 
     return S_ERROR( 'Failed to insert new Instance' )


### PR DESCRIPTION
These bug fixes are tested in IHEP openstack platform
1. VirtualMachineDB
   vm_Instances -> Endpoint changed from VARCHAR(32) to VARCHAR(255)
   The endpoint name is easily longer than 32 chars
2. Variables in bootstrap scripts
   Some arguments are changed to varialbes (SETUP, vo)
3. Destroy vm when assignFloatingIP failed
   The previous code destroy vm only exception catched.
4. When ipPool is not provided in CS, CloudEndpoint now won't try to assign a floating IP for the vm.
   If any error happens when deleteFloatingIP, still try to destroy the vm.
5. If any error happens to one image, just skip it, so that other images could still work
6. VM history status is now consistent with vm status when creation.
   In previous code, the vm status is 'Submitted' and in history it is 'New'. Now they are all 'Submitted'
