### PR TITLE
Multiple endpoint type

### DIFF
--- a/VMDIRAC/Resources/Cloud/CloudEndpoint.py
+++ b/VMDIRAC/Resources/Cloud/CloudEndpoint.py
@@ -176,7 +176,6 @@ class CloudEndpoint( Endpoint ):
 
     # Arguments to the vm-bootstrap command
     bootstrapArgs = { 'dirac-site': self.parameters['Site'],
-                      'submit-pool': self.parameters['SubmitPool'],
                       'ce-name': self.parameters['CEName'],
                       'image-name': self.parameters['Image'],
                       'vm-uuid': self.parameters['VMUUID'],

--- a/VMDIRAC/Resources/Cloud/CloudEndpoint.py
+++ b/VMDIRAC/Resources/Cloud/CloudEndpoint.py
@@ -24,7 +24,6 @@ from DIRAC import gLogger, S_OK, S_ERROR
 from DIRAC.Core.Utilities.File import makeGuid
 
 from VMDIRAC.Resources.Cloud.Endpoint import Endpoint
-from VMDIRAC.Resources.Cloud.Utilities import createMimeData
 
 DEBUG = False
 
@@ -170,100 +169,6 @@ class CloudEndpoint( Endpoint ):
 
     return S_OK( [ secGroup for secGroup in secGroups if secGroup.name in securityGroupNames ] )
 
-  def __createUserDataScript( self ):
-
-    userDataDict = {}
-
-    # Arguments to the vm-bootstrap command
-    bootstrapArgs = { 'dirac-site': self.parameters['Site'],
-                      'ce-name': self.parameters['CEName'],
-                      'image-name': self.parameters['Image'],
-                      'vm-uuid': self.parameters['VMUUID'],
-                      'vmtype': self.parameters['VMType'],
-                      'vo': self.parameters['VO'],
-                      'running-pod': self.parameters['RunningPod'],
-                      'cvmfs-proxy': self.parameters.get( 'CVMFSProxy', 'None' ),
-                      'cs-servers': ','.join( self.parameters.get( 'CSServers', [] ) ),
-                      'release-version': self.parameters['Version'] ,
-                      'release-project': self.parameters['Project'] ,
-                      'setup': self.parameters['Setup'] }
-
-    bootstrapString = ''
-    for key, value in bootstrapArgs.items():
-      bootstrapString += " --%s=%s \\\n" % ( key, value )
-    userDataDict['bootstrapArgs'] = bootstrapString
-
-    userDataDict['user_data_commands_base_url'] = self.parameters.get( 'user_data_commands_base_url' )
-    if not userDataDict['user_data_commands_base_url']:
-      return S_ERROR( 'user_data_commands_base_url is not defined' )
-    with open( self.parameters['HostCert'] ) as cfile:
-      userDataDict['user_data_file_hostkey'] = cfile.read().strip()
-    with open( self.parameters['HostKey'] ) as kfile:
-      userDataDict['user_data_file_hostcert'] = kfile.read().strip()
-
-    # List of commands to be downloaded
-    bootstrapCommands = self.parameters.get( 'user_data_commands' )
-    if isinstance( bootstrapCommands, basestring ):
-      bootstrapCommands = bootstrapCommands.split( ',' )
-    if not bootstrapCommands:
-      return S_ERROR( 'user_data_commands list is not defined' )
-    userDataDict['bootstrapCommands'] = ' '.join( bootstrapCommands )
-
-    script = """
-cat <<X5_EOF >/root/hostkey.pem
-%(user_data_file_hostkey)s
-%(user_data_file_hostcert)s
-X5_EOF
-mkdir -p /var/spool/checkout/context
-cd /var/spool/checkout/context
-for dfile in %(bootstrapCommands)s
-do
-  echo curl --insecure -s %(user_data_commands_base_url)s/$dfile -o $dfile
-  i=7
-  while [ $i -eq 7 ]
-  do
-    curl --insecure -s %(user_data_commands_base_url)s/$dfile -o $dfile
-    i=$?
-    if [ $i -eq 7 ]; then
-      echo curl connection failure for file $dfile
-      sleep 10
-    fi
-  done
-  curl --insecure -s %(user_data_commands_base_url)s/$dfile -o $dfile || echo Download of $dfile failed with $? !
-done
-chmod +x vm-bootstrap
-/var/spool/checkout/context/vm-bootstrap %(bootstrapArgs)s
-#/sbin/shutdown -h now
-    """ % userDataDict
-
-    if "HEPIX" in self.parameters:
-      script = """
-cat <<EP_EOF >>/var/lib/hepix/context/epilog.sh
-#!/bin/sh
-%s
-EP_EOF
-chmod +x /var/lib/hepix/context/epilog.sh
-      """ % script
-
-    user_data = """#!/bin/bash
-mkdir -p /etc/joboutputs
-(
-%s
-) > /etc/joboutputs/user_data.log 2>&1 &
-exit 0
-    """ % script
-
-    cloud_config = """#cloud-config
-
-output: {all: '| tee -a /var/log/cloud-init-output.log'}
-
-cloud_final_modules:
-  - [scripts-user, always]
-    """
-
-    return createMimeData( ( ( user_data, 'text/x-shellscript', 'dirac_boot.sh' ),
-                             ( cloud_config, 'text/cloud-config', 'cloud-config') ) )
-
   def createInstances( self, vmsToSubmit ):
     outputDict = {}
 
@@ -354,7 +259,7 @@ cloud_final_modules:
     #    return result
     #  self.parameters['ex_security_groups'] = result[ 'Value' ]
 
-    result = self.__createUserDataScript()
+    result = self._createUserDataScript()
     if not result['OK']:
       return result
 

--- a/VMDIRAC/Resources/Cloud/ConfigHelper.py
+++ b/VMDIRAC/Resources/Cloud/ConfigHelper.py
@@ -94,7 +94,7 @@ def getImages( siteList = None, ceList = None, imageList = None, vo = None ):
 
   return S_OK( resultDict )
 
-def getImage( site, ce, image ):
+def getVMImageConfig( site, ce, image = '' ):
   """ Get parameters of the specified queue
   """
   Tags = []
@@ -106,15 +106,32 @@ def getImage( site, ce, image ):
   ceTags = resultDict.get( 'Tag' )
   if ceTags:
     Tags = fromChar( ceTags )
-  result = gConfig.getOptionsDict( '/Resources/Sites/%s/%s/Cloud/%s/Images/%s' % ( grid, site, ce, image ) )
-  if not result['OK']:
-    return result
-  resultDict.update( result['Value'] )
-  imageTags = resultDict.get( 'Tag' )
-  if imageTags:
-    imageTags = fromChar( imageTags )
-    Tags = list( set( Tags + imageTags ) )
+
+  if image:
+    result = gConfig.getOptionsDict( '/Resources/Sites/%s/%s/Cloud/%s/Images/%s' % ( grid, site, ce, image ) )
+    if not result['OK']:
+      return result
+    resultDict.update( result['Value'] )
+    queueTags = resultDict.get( 'Tag' )
+    if queueTags:
+      queueTags = fromChar( queueTags )
+      Tags = list( set( Tags + queueTags ) )
+
   if Tags:
     resultDict['Tag'] = Tags
-  resultDict['Queue'] = image
+  resultDict['Image'] = image
+  resultDict['Site'] = site
   return S_OK( resultDict )
+
+def getPilotBootstrapParameters( vo = '' ):
+
+  op = Operations.Operations( vo = vo )
+  result = op.getOptionsDict( 'Cloud' )
+  opParameters = {}
+  if result['OK']:
+    opParameters = result['Value']
+  opParameters['Project'] = op.getValue( 'Cloud/Project', 'DIRAC' )
+  opParameters['Version'] = op.getValue( 'Cloud/Version' )
+  opParameters['Setup'] = gConfig.getValue( '/DIRAC/Setup', 'unknown' )
+  result = op.getOptionsDict( 'Cloud/%s' % self.runningPod )
+  return result

--- a/VMDIRAC/Resources/Cloud/ConfigHelper.py
+++ b/VMDIRAC/Resources/Cloud/ConfigHelper.py
@@ -123,7 +123,7 @@ def getVMImageConfig( site, ce, image = '' ):
   resultDict['Site'] = site
   return S_OK( resultDict )
 
-def getPilotBootstrapParameters( vo = '' ):
+def getPilotBootstrapParameters( vo = '', runningPod = '' ):
 
   op = Operations.Operations( vo = vo )
   result = op.getOptionsDict( 'Cloud' )
@@ -133,5 +133,7 @@ def getPilotBootstrapParameters( vo = '' ):
   opParameters['Project'] = op.getValue( 'Cloud/Project', 'DIRAC' )
   opParameters['Version'] = op.getValue( 'Cloud/Version' )
   opParameters['Setup'] = gConfig.getValue( '/DIRAC/Setup', 'unknown' )
-  result = op.getOptionsDict( 'Cloud/%s' % self.runningPod )
-  return result
+  result = op.getOptionsDict( 'Cloud/%s' % runningPod )
+  if result['OK']:
+    opParameters.update( result['Value'] )
+  return S_OK( opParameters )

--- a/VMDIRAC/Resources/Cloud/ConfigHelper.py
+++ b/VMDIRAC/Resources/Cloud/ConfigHelper.py
@@ -33,6 +33,7 @@ def findGenericCloudCredentials( vo = False, group = False ):
     if not result[ 'OK' ]:
       return S_ERROR( "%s@%s has no proxy in ProxyManager" )
     return S_OK( ( cloudDN, cloudGroup ) )
+  return S_ERROR( "Cloud credentials not found" )
 
 def getImages( siteList = None, ceList = None, imageList = None, vo = None ):
   """ Get CE/image options according to the specified selection

--- a/VMDIRAC/Resources/Cloud/EC2Endpoint.py
+++ b/VMDIRAC/Resources/Cloud/EC2Endpoint.py
@@ -1,0 +1,87 @@
+""" EC2Endpoint class is the implementation of the EC2 interface to
+    a cloud endpoint
+"""
+
+__RCSID__ = '$Id$'
+
+from libcloud.compute.drivers.ec2 import REGION_DETAILS
+
+REGION_DETAILS["cn-north-1"] = {
+        'endpoint': 'ec2.cn-north-1.amazonaws.cn',
+        'api_name': 'ec2_cn_north',
+        'country': 'China',
+        'signature_version': '2',
+        'instance_types': [
+            't1.micro',
+            'm1.small',
+            'm1.medium',
+            'm1.large',
+            'm1.xlarge',
+            'm2.xlarge',
+            'm2.2xlarge',
+            'm2.4xlarge',
+            'm3.medium',
+            'm3.large',
+            'm3.xlarge',
+            'm3.2xlarge',
+            'm4.large',
+            'm4.xlarge',
+            'm4.2xlarge',
+            'm4.4xlarge',
+            'm4.10xlarge',
+            'c1.medium',
+            'c1.xlarge',
+            'cc2.8xlarge',
+            'c3.large',
+            'c3.xlarge',
+            'c3.2xlarge',
+            'c3.4xlarge',
+            'c3.8xlarge',
+            'c4.large',
+            'c4.xlarge',
+            'c4.2xlarge',
+            'c4.4xlarge',
+            'c4.8xlarge',
+            'cg1.4xlarge',
+            'g2.2xlarge',
+            'g2.8xlarge',
+            'cr1.8xlarge',
+            'hs1.8xlarge',
+            'i2.xlarge',
+            'i2.2xlarge',
+            'i2.4xlarge',
+            'i2.8xlarge',
+            'd2.xlarge',
+            'd2.2xlarge',
+            'd2.4xlarge',
+            'd2.8xlarge',
+            'r3.large',
+            'r3.xlarge',
+            'r3.2xlarge',
+            'r3.4xlarge',
+            'r3.8xlarge',
+            't2.nano',
+            't2.micro',
+            't2.small',
+            't2.medium',
+            't2.large'
+        ]
+    }
+
+from DIRAC import gLogger
+from VMDIRAC.Resources.Cloud.CloudEndpoint import CloudEndpoint
+from VMDIRAC.Resources.Cloud.Endpoint import Endpoint
+
+class EC2Endpoint( CloudEndpoint ):
+
+  def __init__( self, parameters = {} ):
+    """
+    """
+    Endpoint.__init__( self, parameters = parameters )
+    # logger
+    self.log = gLogger.getSubLogger( 'EC2Endpoint' )
+    self.valid = False
+    result = self.initialize()
+    if result['OK']:
+      self.log.debug( 'EC2Endpoint created and validated' )
+      self.valid = True

--- a/VMDIRAC/Resources/Cloud/EC2Endpoint.py
+++ b/VMDIRAC/Resources/Cloud/EC2Endpoint.py
@@ -2,77 +2,19 @@
     a cloud endpoint
 """
 
+import os
+import json
+import boto3
+
+from DIRAC import gLogger, S_OK, S_ERROR
+from DIRAC.Core.Utilities.File import makeGuid
+
+from VMDIRAC.Resources.Cloud.Endpoint import Endpoint
+from VMDIRAC.Resources.Cloud.Utilities import createMimeData
+
 __RCSID__ = '$Id$'
 
-from libcloud.compute.drivers.ec2 import REGION_DETAILS
-
-REGION_DETAILS["cn-north-1"] = {
-        'endpoint': 'ec2.cn-north-1.amazonaws.cn',
-        'api_name': 'ec2_cn_north',
-        'country': 'China',
-        'signature_version': '2',
-        'instance_types': [
-            't1.micro',
-            'm1.small',
-            'm1.medium',
-            'm1.large',
-            'm1.xlarge',
-            'm2.xlarge',
-            'm2.2xlarge',
-            'm2.4xlarge',
-            'm3.medium',
-            'm3.large',
-            'm3.xlarge',
-            'm3.2xlarge',
-            'm4.large',
-            'm4.xlarge',
-            'm4.2xlarge',
-            'm4.4xlarge',
-            'm4.10xlarge',
-            'c1.medium',
-            'c1.xlarge',
-            'cc2.8xlarge',
-            'c3.large',
-            'c3.xlarge',
-            'c3.2xlarge',
-            'c3.4xlarge',
-            'c3.8xlarge',
-            'c4.large',
-            'c4.xlarge',
-            'c4.2xlarge',
-            'c4.4xlarge',
-            'c4.8xlarge',
-            'cg1.4xlarge',
-            'g2.2xlarge',
-            'g2.8xlarge',
-            'cr1.8xlarge',
-            'hs1.8xlarge',
-            'i2.xlarge',
-            'i2.2xlarge',
-            'i2.4xlarge',
-            'i2.8xlarge',
-            'd2.xlarge',
-            'd2.2xlarge',
-            'd2.4xlarge',
-            'd2.8xlarge',
-            'r3.large',
-            'r3.xlarge',
-            'r3.2xlarge',
-            'r3.4xlarge',
-            'r3.8xlarge',
-            't2.nano',
-            't2.micro',
-            't2.small',
-            't2.medium',
-            't2.large'
-        ]
-    }
-
-from DIRAC import gLogger
-from VMDIRAC.Resources.Cloud.CloudEndpoint import CloudEndpoint
-from VMDIRAC.Resources.Cloud.Endpoint import Endpoint
-
-class EC2Endpoint( CloudEndpoint ):
+class EC2Endpoint( Endpoint ):
 
   def __init__( self, parameters = {} ):
     """
@@ -85,3 +27,280 @@ class EC2Endpoint( CloudEndpoint ):
     if result['OK']:
       self.log.debug( 'EC2Endpoint created and validated' )
       self.valid = True
+    else:
+      self.log.error( result['Message'] )
+
+  def initialize( self ):
+
+    availableParams = {
+      'RegionName': 'region_name',
+      'AccessKey': 'aws_access_key_id',
+      'SecretKey': 'aws_secret_access_key',
+      'EndpointUrl': 'endpoint_url',          # EndpointUrl is optional
+    }
+
+    connDict = {}
+    for var in availableParams:
+      if var in self.parameters:
+        connDict[ availableParams[ var ] ] = self.parameters[ var ]
+
+    try:
+      self.__ec2 = boto3.resource( 'ec2', **connDict )
+    except Exception, e:
+      errorStatus = "Can't connect to EC2: " + str(e)
+      return S_ERROR( errorStatus )
+
+    result = self.__loadInstanceType()
+    if not result['OK']:
+      return result
+
+    result = self.__checkConnection()
+    return result
+
+  def __loadInstanceType( self ):
+    currentDir = os.path.dirname( os.path.abspath( __file__ ) )
+    instanceTypeFile = os.path.join( currentDir, 'ec2_instance_type.json' )
+    try:
+      with open( instanceTypeFile, 'r' ) as f:
+        self.__instanceTypeInfo = json.load( f )
+    except Exception, e:
+      errmsg = "Exception loading EC2 instance type info: %s" % e
+      self.log.error(  errmsg )
+      return S_ERROR( errmsg )
+
+    return S_OK()
+
+  def __checkConnection( self ):
+    """
+    Checks connection status by trying to list the images.
+
+    :return: S_OK | S_ERROR
+    """
+    try:
+      self.__ec2.images.filter( Owners = ['self'] )
+    except Exception, e:
+      return S_ERROR( e )
+
+    return S_OK()
+
+  def __createUserDataScript( self ):
+
+    userDataDict = {}
+
+    # Arguments to the vm-bootstrap command
+    bootstrapArgs = { 'dirac-site': self.parameters['Site'],
+#                      'submit-pool': self.parameters['SubmitPool'],
+                      'ce-name': self.parameters['CEName'],
+                      'image-name': self.parameters['Image'],
+                      'vm-uuid': self.parameters['VMUUID'],
+                      'vmtype': self.parameters['VMType'],
+                      'vo': self.parameters['VO'],
+                      'running-pod': self.parameters['RunningPod'],
+                      'cvmfs-proxy': self.parameters.get( 'CVMFSProxy', 'None' ),
+                      'cs-servers': ','.join( self.parameters.get( 'CSServers', [] ) ),
+                      'release-version': self.parameters['Version'] ,
+                      'release-project': self.parameters['Project'] ,
+                      'setup': self.parameters['Setup'] }
+
+    bootstrapString = ''
+    for key, value in bootstrapArgs.items():
+      bootstrapString += " --%s=%s \\\n" % ( key, value )
+    userDataDict['bootstrapArgs'] = bootstrapString
+
+    userDataDict['user_data_commands_base_url'] = self.parameters.get( 'user_data_commands_base_url' )
+    if not userDataDict['user_data_commands_base_url']:
+      return S_ERROR( 'user_data_commands_base_url is not defined' )
+    with open( self.parameters['HostCert'] ) as cfile:
+      userDataDict['user_data_file_hostkey'] = cfile.read().strip()
+    with open( self.parameters['HostKey'] ) as kfile:
+      userDataDict['user_data_file_hostcert'] = kfile.read().strip()
+
+    # List of commands to be downloaded
+    bootstrapCommands = self.parameters.get( 'user_data_commands' )
+    if isinstance( bootstrapCommands, basestring ):
+      bootstrapCommands = bootstrapCommands.split( ',' )
+    if not bootstrapCommands:
+      return S_ERROR( 'user_data_commands list is not defined' )
+    userDataDict['bootstrapCommands'] = ' '.join( bootstrapCommands )
+
+    script = """
+cat <<X5_EOF >/root/hostkey.pem
+%(user_data_file_hostkey)s
+%(user_data_file_hostcert)s
+X5_EOF
+mkdir -p /var/spool/checkout/context
+cd /var/spool/checkout/context
+for dfile in %(bootstrapCommands)s
+do
+  echo curl --insecure -s %(user_data_commands_base_url)s/$dfile -o $dfile
+  i=7
+  while [ $i -eq 7 ]
+  do
+    curl --insecure -s %(user_data_commands_base_url)s/$dfile -o $dfile
+    i=$?
+    if [ $i -eq 7 ]; then
+      echo curl connection failure for file $dfile
+      sleep 10
+    fi
+  done
+  curl --insecure -s %(user_data_commands_base_url)s/$dfile -o $dfile || echo Download of $dfile failed with $? !
+done
+chmod +x vm-bootstrap
+/var/spool/checkout/context/vm-bootstrap %(bootstrapArgs)s
+#/sbin/shutdown -h now
+    """ % userDataDict
+
+    if "HEPIX" in self.parameters:
+      script = """
+cat <<EP_EOF >>/var/lib/hepix/context/epilog.sh
+#!/bin/sh
+%s
+EP_EOF
+chmod +x /var/lib/hepix/context/epilog.sh
+      """ % script
+
+    user_data = """#!/bin/bash
+mkdir -p /etc/joboutputs
+(
+%s
+) > /etc/joboutputs/user_data.log 2>&1 &
+exit 0
+    """ % script
+
+    cloud_config = """#cloud-config
+
+output: {all: '| tee -a /var/log/cloud-init-output.log'}
+
+cloud_final_modules:
+  - [scripts-user, always]
+    """
+
+    return createMimeData( ( ( user_data, 'text/x-shellscript', 'dirac_boot.sh' ),
+                             ( cloud_config, 'text/cloud-config', 'cloud-config') ) )
+
+  def createInstances( self, vmsToSubmit ):
+    outputDict = {}
+
+    print '::::::::::::::::: number: %s' % vmsToSubmit
+    for nvm in xrange( vmsToSubmit ):
+      instanceID = makeGuid()[:8]
+      result = self.createInstance( instanceID )
+      print '::::::::::::::::: createInstance result: %s' % result
+      if result['OK']:
+        ec2Id, nodeDict = result['Value']
+        self.log.debug( 'Created VM instance %s/%s' % ( ec2Id, instanceID ) )
+        outputDict[ec2Id] = nodeDict
+      else:
+        break
+
+    return S_OK( outputDict )
+
+  def createInstance( self, instanceID = ''  ):
+    if not instanceID:
+      instanceID = makeGuid()[:8]
+
+    self.parameters['VMUUID'] = instanceID
+    self.parameters['VMType'] = self.parameters.get( 'CEType', 'EC2' )
+
+    createNodeDict = {}
+
+    # Image
+    if not "ImageID" in self.parameters and 'ImageName' in self.parameters:
+      try:
+        images = self.__ec2.images.filter( Filters = [{'Name': 'name', 'Values': [self.parameters['ImageName']]}] )
+        imageId = None
+        for image in images:
+          imageId = image.id
+          break
+      except Exception as e:
+        return S_ERROR( "Failed to get image for Name %s" % self.parameters['ImageName'] )
+      if imageId is None:
+        return S_ERROR( "Image name %s not found" % self.parameters['ImageName'] )
+    elif "ImageID" in self.parameters:
+      try:
+        self.__ec2.images.filter( ImageIds = [self.parameters['ImageID']] )
+      except Exception as e:
+        return S_ERROR( "Failed to get image for ID %s" % self.parameters['ImageID'] )
+      imageId = self.parameters['ImageID']
+    else:
+      return S_ERROR( 'No image specified' )
+    createNodeDict['ImageId'] = imageId
+
+    # Instance type
+    if 'FlavorName' not in self.parameters:
+      return S_ERROR( 'No flavor specified' )
+    instanceType = self.parameters['FlavorName']
+    createNodeDict['InstanceType'] = instanceType
+
+    # User data
+    result = self.__createUserDataScript()
+    if not result['OK']:
+      return result
+    createNodeDict['UserData'] = str( result['Value'] )
+
+    # Other params
+    for param in [ 'KeyName', 'SubnetId', 'EbsOptimized' ]:
+      if param in self.parameters:
+        createNodeDict[param] = self.parameters[param]
+
+    self.log.info( "Creating node:" )
+    for key, value in createNodeDict.items():
+      self.log.verbose( "%s: %s" % ( key, value ) )
+
+    # Create the VM instance now
+    try:
+      instances = self.__ec2.create_instances( MinCount = 1, MaxCount = 1, **createNodeDict )
+    except Exception as e:
+      errmsg = 'Exception in ec2 create_instances: %s' % e
+      self.log.error( errmsg )
+      return S_ERROR( errmsg )
+
+    if len(instances) < 1:
+      errmsg = 'ec2 create_instances failed to create any VM'
+      self.log.error( errmsg )
+      return S_ERROR( errmsg )
+
+    # Create the name in tags
+    ec2Id = instances[0].id
+    tags = [{ 'Key': 'Name', 'Value': 'DIRAC_%s' % instanceID }]
+    try:
+      self.__ec2.create_tags( Resources = [ec2Id], Tags = tags )
+    except Exception as e:
+      errmsg = 'Exception setup name for %s: %s' % ( ec2Id, e )
+      self.log.error( errmsg )
+      return S_ERROR( errmsg )
+
+    # Properties of the instance
+    nodeDict = {}
+#    nodeDict['PublicIP'] = publicIP
+    nodeDict['InstanceID'] = instanceID
+    if instanceType in self.__instanceTypeInfo:
+      nodeDict['NumberOfCPUs'] = self.__instanceTypeInfo[instanceType]['vCPU']
+      nodeDict['RAM'] = self.__instanceTypeInfo[instanceType]['Memory']
+    else:
+      nodeDict['NumberOfCPUs'] = 1
+
+    return S_OK( ( ec2Id, nodeDict ) )
+
+  def stopVM( self, nodeID, publicIP = '' ):
+    """
+    Given the node ID it gets the node details, which are used to destroy the
+    node making use of the libcloud.openstack driver. If three is any public IP
+    ( floating IP ) assigned, frees it as well.
+
+    :Parameters:
+      **uniqueId** - `string`
+        openstack node id ( not uuid ! )
+      **public_ip** - `string`
+        public IP assigned to the node if any
+
+    :return: S_OK | S_ERROR
+    """
+    try:
+      self.__ec2.Instance( nodeID ).terminate()
+    except Exception as e:
+      errmsg = 'Exception terminate instance %s: %s' % ( nodeID, e )
+      self.log.error( errmsg )
+      return S_ERROR( errmsg )
+
+    return S_OK()

--- a/VMDIRAC/Resources/Cloud/EC2Endpoint.py
+++ b/VMDIRAC/Resources/Cloud/EC2Endpoint.py
@@ -93,6 +93,7 @@ class EC2Endpoint( Endpoint ):
         self.log.debug( 'Created VM instance %s/%s' % ( ec2Id, instanceID ) )
         outputDict[ec2Id] = nodeDict
       else:
+        self.log.error( 'Create EC2 instance error:', result['Message'] )
         break
 
     return S_OK( outputDict )
@@ -115,6 +116,7 @@ class EC2Endpoint( Endpoint ):
           imageId = image.id
           break
       except Exception as e:
+        self.log.error( "Exception when get ID from image name %s:" % self.parameters['ImageName'], e )
         return S_ERROR( "Failed to get image for Name %s" % self.parameters['ImageName'] )
       if imageId is None:
         return S_ERROR( "Image name %s not found" % self.parameters['ImageName'] )

--- a/VMDIRAC/Resources/Cloud/EC2Endpoint.py
+++ b/VMDIRAC/Resources/Cloud/EC2Endpoint.py
@@ -10,7 +10,6 @@ from DIRAC import gLogger, S_OK, S_ERROR
 from DIRAC.Core.Utilities.File import makeGuid
 
 from VMDIRAC.Resources.Cloud.Endpoint import Endpoint
-from VMDIRAC.Resources.Cloud.Utilities import createMimeData
 
 __RCSID__ = '$Id$'
 
@@ -83,101 +82,6 @@ class EC2Endpoint( Endpoint ):
 
     return S_OK()
 
-  def __createUserDataScript( self ):
-
-    userDataDict = {}
-
-    # Arguments to the vm-bootstrap command
-    bootstrapArgs = { 'dirac-site': self.parameters['Site'],
-#                      'submit-pool': self.parameters['SubmitPool'],
-                      'ce-name': self.parameters['CEName'],
-                      'image-name': self.parameters['Image'],
-                      'vm-uuid': self.parameters['VMUUID'],
-                      'vmtype': self.parameters['VMType'],
-                      'vo': self.parameters['VO'],
-                      'running-pod': self.parameters['RunningPod'],
-                      'cvmfs-proxy': self.parameters.get( 'CVMFSProxy', 'None' ),
-                      'cs-servers': ','.join( self.parameters.get( 'CSServers', [] ) ),
-                      'release-version': self.parameters['Version'] ,
-                      'release-project': self.parameters['Project'] ,
-                      'setup': self.parameters['Setup'] }
-
-    bootstrapString = ''
-    for key, value in bootstrapArgs.items():
-      bootstrapString += " --%s=%s \\\n" % ( key, value )
-    userDataDict['bootstrapArgs'] = bootstrapString
-
-    userDataDict['user_data_commands_base_url'] = self.parameters.get( 'user_data_commands_base_url' )
-    if not userDataDict['user_data_commands_base_url']:
-      return S_ERROR( 'user_data_commands_base_url is not defined' )
-    with open( self.parameters['HostCert'] ) as cfile:
-      userDataDict['user_data_file_hostkey'] = cfile.read().strip()
-    with open( self.parameters['HostKey'] ) as kfile:
-      userDataDict['user_data_file_hostcert'] = kfile.read().strip()
-
-    # List of commands to be downloaded
-    bootstrapCommands = self.parameters.get( 'user_data_commands' )
-    if isinstance( bootstrapCommands, basestring ):
-      bootstrapCommands = bootstrapCommands.split( ',' )
-    if not bootstrapCommands:
-      return S_ERROR( 'user_data_commands list is not defined' )
-    userDataDict['bootstrapCommands'] = ' '.join( bootstrapCommands )
-
-    script = """
-cat <<X5_EOF >/root/hostkey.pem
-%(user_data_file_hostkey)s
-%(user_data_file_hostcert)s
-X5_EOF
-mkdir -p /var/spool/checkout/context
-cd /var/spool/checkout/context
-for dfile in %(bootstrapCommands)s
-do
-  echo curl --insecure -s %(user_data_commands_base_url)s/$dfile -o $dfile
-  i=7
-  while [ $i -eq 7 ]
-  do
-    curl --insecure -s %(user_data_commands_base_url)s/$dfile -o $dfile
-    i=$?
-    if [ $i -eq 7 ]; then
-      echo curl connection failure for file $dfile
-      sleep 10
-    fi
-  done
-  curl --insecure -s %(user_data_commands_base_url)s/$dfile -o $dfile || echo Download of $dfile failed with $? !
-done
-chmod +x vm-bootstrap
-/var/spool/checkout/context/vm-bootstrap %(bootstrapArgs)s
-#/sbin/shutdown -h now
-    """ % userDataDict
-
-    if "HEPIX" in self.parameters:
-      script = """
-cat <<EP_EOF >>/var/lib/hepix/context/epilog.sh
-#!/bin/sh
-%s
-EP_EOF
-chmod +x /var/lib/hepix/context/epilog.sh
-      """ % script
-
-    user_data = """#!/bin/bash
-mkdir -p /etc/joboutputs
-(
-%s
-) > /etc/joboutputs/user_data.log 2>&1 &
-exit 0
-    """ % script
-
-    cloud_config = """#cloud-config
-
-output: {all: '| tee -a /var/log/cloud-init-output.log'}
-
-cloud_final_modules:
-  - [scripts-user, always]
-    """
-
-    return createMimeData( ( ( user_data, 'text/x-shellscript', 'dirac_boot.sh' ),
-                             ( cloud_config, 'text/cloud-config', 'cloud-config') ) )
-
   def createInstances( self, vmsToSubmit ):
     outputDict = {}
 
@@ -231,7 +135,7 @@ cloud_final_modules:
     createNodeDict['InstanceType'] = instanceType
 
     # User data
-    result = self.__createUserDataScript()
+    result = self._createUserDataScript()
     if not result['OK']:
       return result
     createNodeDict['UserData'] = str( result['Value'] )

--- a/VMDIRAC/Resources/Cloud/Endpoint.py
+++ b/VMDIRAC/Resources/Cloud/Endpoint.py
@@ -16,7 +16,6 @@ class Endpoint( object ):
     """
     """
     # logger
-    self.valid = False
     self.parameters = parameters
     self.valid = False
 
@@ -30,6 +29,4 @@ class Endpoint( object ):
     return self.parameters
 
   def initialize( self ):
-
     pass
-

--- a/VMDIRAC/Resources/Cloud/Endpoint.py
+++ b/VMDIRAC/Resources/Cloud/Endpoint.py
@@ -1,0 +1,35 @@
+###########################################################
+# $HeadURL$
+###########################################################
+
+"""
+   CloudEndpoint is a base class for the clients used to connect to different
+   cloud providers
+"""
+
+__RCSID__ = '$Id$'
+
+class Endpoint( object ):
+  """ Endpoint base class
+  """
+  def __init__( self, parameters = {} ):
+    """
+    """
+    # logger
+    self.valid = False
+    self.parameters = parameters
+    self.valid = False
+
+  def isValid( self ):
+    return self.valid
+
+  def setParameters( self, parameters ):
+    self.parameters = parameters
+
+  def getParameterDict( self ):
+    return self.parameters
+
+  def initialize( self ):
+
+    pass
+

--- a/VMDIRAC/Resources/Cloud/Endpoint.py
+++ b/VMDIRAC/Resources/Cloud/Endpoint.py
@@ -7,6 +7,8 @@
    cloud providers
 """
 
+from VMDIRAC.Resources.Cloud.Utilities import createMimeData
+
 __RCSID__ = '$Id$'
 
 class Endpoint( object ):
@@ -30,3 +32,98 @@ class Endpoint( object ):
 
   def initialize( self ):
     pass
+
+  def _createUserDataScript( self ):
+
+    userDataDict = {}
+
+    # Arguments to the vm-bootstrap command
+    bootstrapArgs = { 'dirac-site': self.parameters['Site'],
+#                      'submit-pool': self.parameters['SubmitPool'],
+                      'ce-name': self.parameters['CEName'],
+                      'image-name': self.parameters['Image'],
+                      'vm-uuid': self.parameters['VMUUID'],
+                      'vmtype': self.parameters['VMType'],
+                      'vo': self.parameters['VO'],
+                      'running-pod': self.parameters['RunningPod'],
+                      'cvmfs-proxy': self.parameters.get( 'CVMFSProxy', 'None' ),
+                      'cs-servers': ','.join( self.parameters.get( 'CSServers', [] ) ),
+                      'release-version': self.parameters['Version'] ,
+                      'release-project': self.parameters['Project'] ,
+                      'setup': self.parameters['Setup'] }
+
+    bootstrapString = ''
+    for key, value in bootstrapArgs.items():
+      bootstrapString += " --%s=%s \\\n" % ( key, value )
+    userDataDict['bootstrapArgs'] = bootstrapString
+
+    userDataDict['user_data_commands_base_url'] = self.parameters.get( 'user_data_commands_base_url' )
+    if not userDataDict['user_data_commands_base_url']:
+      return S_ERROR( 'user_data_commands_base_url is not defined' )
+    with open( self.parameters['HostCert'] ) as cfile:
+      userDataDict['user_data_file_hostkey'] = cfile.read().strip()
+    with open( self.parameters['HostKey'] ) as kfile:
+      userDataDict['user_data_file_hostcert'] = kfile.read().strip()
+
+    # List of commands to be downloaded
+    bootstrapCommands = self.parameters.get( 'user_data_commands' )
+    if isinstance( bootstrapCommands, basestring ):
+      bootstrapCommands = bootstrapCommands.split( ',' )
+    if not bootstrapCommands:
+      return S_ERROR( 'user_data_commands list is not defined' )
+    userDataDict['bootstrapCommands'] = ' '.join( bootstrapCommands )
+
+    script = """
+cat <<X5_EOF >/root/hostkey.pem
+%(user_data_file_hostkey)s
+%(user_data_file_hostcert)s
+X5_EOF
+mkdir -p /var/spool/checkout/context
+cd /var/spool/checkout/context
+for dfile in %(bootstrapCommands)s
+do
+  echo curl --insecure -s %(user_data_commands_base_url)s/$dfile -o $dfile
+  i=7
+  while [ $i -eq 7 ]
+  do
+    curl --insecure -s %(user_data_commands_base_url)s/$dfile -o $dfile
+    i=$?
+    if [ $i -eq 7 ]; then
+      echo curl connection failure for file $dfile
+      sleep 10
+    fi
+  done
+  curl --insecure -s %(user_data_commands_base_url)s/$dfile -o $dfile || echo Download of $dfile failed with $? !
+done
+chmod +x vm-bootstrap
+/var/spool/checkout/context/vm-bootstrap %(bootstrapArgs)s
+#/sbin/shutdown -h now
+    """ % userDataDict
+
+    if "HEPIX" in self.parameters:
+      script = """
+cat <<EP_EOF >>/var/lib/hepix/context/epilog.sh
+#!/bin/sh
+%s
+EP_EOF
+chmod +x /var/lib/hepix/context/epilog.sh
+      """ % script
+
+    user_data = """#!/bin/bash
+mkdir -p /etc/joboutputs
+(
+%s
+) > /etc/joboutputs/user_data.log 2>&1 &
+exit 0
+    """ % script
+
+    cloud_config = """#cloud-config
+
+output: {all: '| tee -a /var/log/cloud-init-output.log'}
+
+cloud_final_modules:
+  - [scripts-user, always]
+    """
+
+    return createMimeData( ( ( user_data, 'text/x-shellscript', 'dirac_boot.sh' ),
+                             ( cloud_config, 'text/cloud-config', 'cloud-config') ) )

--- a/VMDIRAC/Resources/Cloud/EndpointFactory.py
+++ b/VMDIRAC/Resources/Cloud/EndpointFactory.py
@@ -1,26 +1,23 @@
 ########################################################################
-# File :   CloudEndpointFactory.py
+# File :   EndpointFactory.py
 # Author : Andrei Tsaregorodtsev
 ########################################################################
 
 """  The Cloud Endpoint Factory has one method that instantiates a given Cloud Endpoint
 """
-from DIRAC                             import S_OK, S_ERROR, gLogger
-from DIRAC.Core.Utilities              import ObjectLoader
-from VMDIRAC.Resources.Cloud.Utilities import getVMImageConfig
+from DIRAC                                import S_OK, S_ERROR, gLogger
+from DIRAC.Core.Utilities                 import ObjectLoader
+from VMDIRAC.Resources.Cloud.ConfigHelper import getVMImageConfig
 
 __RCSID__ = "$Id$"
 
-class CloudEndpointFactory( object ):
+class EndpointFactory( object ):
 
   #############################################################################
-  def __init__(self, ceType=''):
+  def __init__(self):
     """ Standard constructor
     """
-    self.ceType = 'Base'
-    if ceType:
-      self.ceType = ceType
-    self.log = gLogger.getSubLogger( self.ceType )
+    self.log = gLogger.getSubLogger( 'EndpointFactory' )
 
   def getCE( self, site, endpoint, image = '' ):
 
@@ -33,17 +30,16 @@ class CloudEndpointFactory( object ):
     return result
 
   #############################################################################
-  def getCEObject( self, ceType = '', parameters = {} ):
+  def getCEObject( self, parameters = {} ):
     """This method returns the CloudEndpoint instance corresponding to the supplied
        CEUniqueID.  If no corresponding CE is available, this is indicated.
     """
-    ceTypeLocal = ceType
-    if not ceTypeLocal:
-      ceTypeLocal = self.ceType
-    self.log.verbose('Creating CloudEndpoint of %s type' % ceTypeLocal )
-    subClassName = "%sCloudEndpoint" % (ceTypeLocal)
-    if ceTypeLocal == "Base":
-      subClassName = "CloudEndpoint"
+
+    print "AT >>> getCEObject", parameters
+
+    ceType = parameters.get( 'CEType', 'Cloud' )
+    self.log.verbose('Creating Endpoint of %s type' % ceType )
+    subClassName = "%sEndpoint" % (ceType)
 
     objectLoader = ObjectLoader.ObjectLoader()
     result = objectLoader.loadObject( 'Resources.Cloud.%s' % subClassName, subClassName )
@@ -53,13 +49,16 @@ class CloudEndpointFactory( object ):
 
     ceClass = result['Value']
     try:
-      cloudEndpoint = ceClass( parameters )
+
+      print "AT >>> getCEObject", parameters, ceClass
+
+      endpoint = ceClass( parameters )
     except Exception as x:
-      msg = 'CloudEndpointFactory could not instantiate %s object: %s' % ( subClassName, str( x ) )
+      msg = 'EndpointFactory could not instantiate %s object: %s' % ( subClassName, str( x ) )
       self.log.exception()
       self.log.warn( msg )
       return S_ERROR( msg )
 
-    return S_OK( cloudEndpoint )
+    return S_OK( endpoint )
 
 #EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#EOF#

--- a/VMDIRAC/Resources/Cloud/EndpointFactory.py
+++ b/VMDIRAC/Resources/Cloud/EndpointFactory.py
@@ -34,9 +34,6 @@ class EndpointFactory( object ):
     """This method returns the CloudEndpoint instance corresponding to the supplied
        CEUniqueID.  If no corresponding CE is available, this is indicated.
     """
-
-    print "AT >>> getCEObject", parameters
-
     ceType = parameters.get( 'CEType', 'Cloud' )
     self.log.verbose('Creating Endpoint of %s type' % ceType )
     subClassName = "%sEndpoint" % (ceType)
@@ -49,9 +46,6 @@ class EndpointFactory( object ):
 
     ceClass = result['Value']
     try:
-
-      print "AT >>> getCEObject", parameters, ceClass
-
       endpoint = ceClass( parameters )
     except Exception as x:
       msg = 'EndpointFactory could not instantiate %s object: %s' % ( subClassName, str( x ) )

--- a/VMDIRAC/Resources/Cloud/RocciEndpoint.py
+++ b/VMDIRAC/Resources/Cloud/RocciEndpoint.py
@@ -11,7 +11,6 @@ from DIRAC import gLogger, S_OK, S_ERROR
 from DIRAC.Core.Utilities.File import makeGuid
 
 from VMDIRAC.Resources.Cloud.Endpoint import Endpoint
-from VMDIRAC.Resources.Cloud.Utilities import createMimeData
 
 __RCSID__ = '$Id$'
 
@@ -119,101 +118,6 @@ class RocciEndpoint( Endpoint ):
 
     return S_OK( imageIds[-1] )
 
-  def __createUserDataScript( self ):
-
-    userDataDict = {}
-
-    # Arguments to the vm-bootstrap command
-    bootstrapArgs = { 'dirac-site': self.parameters['Site'],
-#                      'submit-pool': self.parameters['SubmitPool'],
-                      'ce-name': self.parameters['CEName'],
-                      'image-name': self.parameters['Image'],
-                      'vm-uuid': self.parameters['VMUUID'],
-                      'vmtype': self.parameters['VMType'],
-                      'vo': self.parameters['VO'],
-                      'running-pod': self.parameters['RunningPod'],
-                      'cvmfs-proxy': self.parameters.get( 'CVMFSProxy', 'None' ),
-                      'cs-servers': ','.join( self.parameters.get( 'CSServers', [] ) ),
-                      'release-version': self.parameters['Version'] ,
-                      'release-project': self.parameters['Project'] ,
-                      'setup': self.parameters['Setup'] }
-
-    bootstrapString = ''
-    for key, value in bootstrapArgs.items():
-      bootstrapString += " --%s=%s \\\n" % ( key, value )
-    userDataDict['bootstrapArgs'] = bootstrapString
-
-    userDataDict['user_data_commands_base_url'] = self.parameters.get( 'user_data_commands_base_url' )
-    if not userDataDict['user_data_commands_base_url']:
-      return S_ERROR( 'user_data_commands_base_url is not defined' )
-    with open( self.parameters['HostCert'] ) as cfile:
-      userDataDict['user_data_file_hostkey'] = cfile.read().strip()
-    with open( self.parameters['HostKey'] ) as kfile:
-      userDataDict['user_data_file_hostcert'] = kfile.read().strip()
-
-    # List of commands to be downloaded
-    bootstrapCommands = self.parameters.get( 'user_data_commands' )
-    if isinstance( bootstrapCommands, basestring ):
-      bootstrapCommands = bootstrapCommands.split( ',' )
-    if not bootstrapCommands:
-      return S_ERROR( 'user_data_commands list is not defined' )
-    userDataDict['bootstrapCommands'] = ' '.join( bootstrapCommands )
-
-    script = """
-cat <<X5_EOF >/root/hostkey.pem
-%(user_data_file_hostkey)s
-%(user_data_file_hostcert)s
-X5_EOF
-mkdir -p /var/spool/checkout/context
-cd /var/spool/checkout/context
-for dfile in %(bootstrapCommands)s
-do
-  echo curl --insecure -s %(user_data_commands_base_url)s/$dfile -o $dfile
-  i=7
-  while [ $i -eq 7 ]
-  do
-    curl --insecure -s %(user_data_commands_base_url)s/$dfile -o $dfile
-    i=$?
-    if [ $i -eq 7 ]; then
-      echo curl connection failure for file $dfile
-      sleep 10
-    fi
-  done
-  curl --insecure -s %(user_data_commands_base_url)s/$dfile -o $dfile || echo Download of $dfile failed with $? !
-done
-chmod +x vm-bootstrap
-/var/spool/checkout/context/vm-bootstrap %(bootstrapArgs)s
-#/sbin/shutdown -h now
-    """ % userDataDict
-
-    if "HEPIX" in self.parameters:
-      script = """
-cat <<EP_EOF >>/var/lib/hepix/context/epilog.sh
-#!/bin/sh
-%s
-EP_EOF
-chmod +x /var/lib/hepix/context/epilog.sh
-      """ % script
-
-    user_data = """#!/bin/bash
-mkdir -p /etc/joboutputs
-(
-%s
-) > /etc/joboutputs/user_data.log 2>&1 &
-exit 0
-    """ % script
-
-    cloud_config = """#cloud-config
-
-output: {all: '| tee -a /var/log/cloud-init-output.log'}
-
-cloud_final_modules:
-  - [scripts-user, always]
-    """
-
-    return createMimeData( ( ( user_data, 'text/x-shellscript', 'dirac_boot.sh' ),
-                             ( cloud_config, 'text/cloud-config', 'cloud-config') ) )
-
   def createInstances( self, vmsToSubmit ):
     outputDict = {}
 
@@ -273,7 +177,7 @@ cloud_final_modules:
     self.log.verbose( ' '.join( actionArgs ) )
 
     # User data
-    result = self.__createUserDataScript()
+    result = self._createUserDataScript()
     if not result['OK']:
       return result
 #    actionArgs += ['--context', 'user_data=%s' % str( result['Value'] )]

--- a/VMDIRAC/Resources/Cloud/RocciEndpoint.py
+++ b/VMDIRAC/Resources/Cloud/RocciEndpoint.py
@@ -129,6 +129,7 @@ class RocciEndpoint( Endpoint ):
         self.log.debug( 'Created VM instance %s/%s' % ( occiId, instanceID ) )
         outputDict[occiId] = nodeDict
       else:
+        self.log.error( 'Create Rocci instance error:', result['Message'] )
         break
 
     return S_OK( outputDict )
@@ -217,7 +218,7 @@ class RocciEndpoint( Endpoint ):
     actionArgs = ['--action', 'delete', '--resource', nodeID]
     result = self.__occiCommand( actionArgs )
     if not result['OK']:
-      errmsg = 'Exception terminate instance %s: %s' % ( nodeID, e )
+      errmsg = 'Can not terminate instance %s: %s' % ( nodeID, result['Message'] )
       self.log.error( errmsg )
       return S_ERROR( errmsg )
 

--- a/VMDIRAC/Resources/Cloud/Utilities.py
+++ b/VMDIRAC/Resources/Cloud/Utilities.py
@@ -1,5 +1,8 @@
-from DIRAC import gConfig, S_OK
-from DIRAC.Core.Utilities.List import fromChar
+import sys
+
+from DIRAC import S_OK, S_ERROR
+from email.mime.text import MIMEText
+from email.mime.multipart import MIMEMultipart
 
 STATE_MAP = { 0: 'RUNNING',
               1: 'REBOOTING',
@@ -11,31 +14,15 @@ STATE_MAP = { 0: 'RUNNING',
               7: 'ERROR',
               8: 'PAUSED' }
 
-def getVMImageConfig( site, ce, image = '' ):
-  """ Get parameters of the specified queue
-  """
-  Tags = []
-  grid = site.split( '.' )[0]
-  result = gConfig.getOptionsDict( '/Resources/Sites/%s/%s/Cloud/%s' % ( grid, site, ce ) )
-  if not result['OK']:
-    return result
-  resultDict = result['Value']
-  ceTags = resultDict.get( 'Tag' )
-  if ceTags:
-    Tags = fromChar( ceTags )
+def createMimeData( userDataTuple ):
 
-  if image:
-    result = gConfig.getOptionsDict( '/Resources/Sites/%s/%s/Cloud/%s/Images/%s' % ( grid, site, ce, image ) )
-    if not result['OK']:
-      return result
-    resultDict.update( result['Value'] )
-    queueTags = resultDict.get( 'Tag' )
-    if queueTags:
-      queueTags = fromChar( queueTags )
-      Tags = list( set( Tags + queueTags ) )
+  userData = MIMEMultipart()
+  for contents, mtype, fname in userDataTuple:
+    try:
+      mimeText = MIMEText(contents, mtype, sys.getdefaultencoding())
+      mimeText.add_header('Content-Disposition', 'attachment; filename="%s"' % fname )
+      userData.attach( mimeText )
+    except Exception as e:
+      return S_ERROR( str( e ) )
 
-  if Tags:
-    resultDict['Tag'] = Tags
-  resultDict['Image'] = image
-  resultDict['Site'] = site
-  return S_OK( resultDict )
+  return S_OK( userData )

--- a/VMDIRAC/Resources/Cloud/ec2_instance_type.json
+++ b/VMDIRAC/Resources/Cloud/ec2_instance_type.json
@@ -1,0 +1,162 @@
+{
+  "t2.nano": {
+    "Memory": 0.5, 
+    "vCPU": 1
+  }, 
+  "t2.micro": {
+    "Memory": 1.0, 
+    "vCPU": 1
+  }, 
+  "t2.small": {
+    "Memory": 2.0, 
+    "vCPU": 1
+  }, 
+  "t2.medium": {
+    "Memory": 4.0, 
+    "vCPU": 2
+  }, 
+  "t2.large": {
+    "Memory": 8.0, 
+    "vCPU": 2
+  }, 
+  "m4.large": {
+    "Memory": 8.0, 
+    "vCPU": 2
+  }, 
+  "m4.xlarge": {
+    "Memory": 16.0, 
+    "vCPU": 4
+  }, 
+  "m4.2xlarge": {
+    "Memory": 32.0, 
+    "vCPU": 8
+  }, 
+  "m4.4xlarge": {
+    "Memory": 64.0, 
+    "vCPU": 16
+  }, 
+  "m4.10xlarge": {
+    "Memory": 160.0, 
+    "vCPU": 40
+  }, 
+  "m3.medium": {
+    "Memory": 3.75, 
+    "vCPU": 1
+  }, 
+  "m3.large": {
+    "Memory": 7.5, 
+    "vCPU": 2
+  }, 
+  "m3.xlarge": {
+    "Memory": 15.0, 
+    "vCPU": 4
+  }, 
+  "m3.2xlarge": {
+    "Memory": 30.0, 
+    "vCPU": 8
+  }, 
+  "c4.large": {
+    "Memory": 3.75, 
+    "vCPU": 2
+  }, 
+  "c4.xlarge": {
+    "Memory": 7.5, 
+    "vCPU": 4
+  }, 
+  "c4.2xlarge": {
+    "Memory": 15.0, 
+    "vCPU": 8
+  }, 
+  "c4.4xlarge": {
+    "Memory": 30.0, 
+    "vCPU": 16
+  }, 
+  "c4.8xlarge": {
+    "Memory": 60.0, 
+    "vCPU": 36
+  }, 
+  "c3.large": {
+    "Memory": 3.75, 
+    "vCPU": 2
+  }, 
+  "c3.xlarge": {
+    "Memory": 7.5, 
+    "vCPU": 4
+  }, 
+  "c3.2xlarge": {
+    "Memory": 15.0, 
+    "vCPU": 8
+  }, 
+  "c3.4xlarge": {
+    "Memory": 30.0, 
+    "vCPU": 16
+  }, 
+  "c3.8xlarge": {
+    "Memory": 60.0, 
+    "vCPU": 32
+  }, 
+  "g2.2xlarge": {
+    "Memory": 15.0, 
+    "vCPU": 8
+  }, 
+  "g2.8xlarge": {
+    "Memory": 60.0, 
+    "vCPU": 32
+  }, 
+  "x1.32xlarge": {
+    "Memory": 1952.0, 
+    "vCPU": 128
+  }, 
+  "r3.large": {
+    "Memory": 15.25, 
+    "vCPU": 2
+  }, 
+  "r3.xlarge": {
+    "Memory": 30.5, 
+    "vCPU": 4
+  }, 
+  "r3.2xlarge": {
+    "Memory": 61.0, 
+    "vCPU": 8
+  }, 
+  "r3.4xlarge": {
+    "Memory": 122.0, 
+    "vCPU": 16
+  }, 
+  "r3.8xlarge": {
+    "Memory": 244.0, 
+    "vCPU": 32
+  }, 
+  "i2.xlarge": {
+    "Memory": 30.5, 
+    "vCPU": 4
+  }, 
+  "i2.2xlarge": {
+    "Memory": 61.0, 
+    "vCPU": 8
+  }, 
+  "i2.4xlarge": {
+    "Memory": 122.0, 
+    "vCPU": 16
+  }, 
+  "i2.8xlarge": {
+    "Memory": 244.0, 
+    "vCPU": 32
+  }, 
+  "d2.xlarge": {
+    "Memory": 30.5, 
+    "vCPU": 4
+  }, 
+  "d2.2xlarge": {
+    "Memory": 61.0, 
+    "vCPU": 8
+  }, 
+  "d2.4xlarge": {
+    "Memory": 122.0, 
+    "vCPU": 16
+  }, 
+  "d2.8xlarge": {
+    "Memory": 244.0, 
+    "vCPU": 36
+  }
+}

--- a/VMDIRAC/WorkloadManagementSystem/Agent/CloudDirector.py
+++ b/VMDIRAC/WorkloadManagementSystem/Agent/CloudDirector.py
@@ -22,8 +22,8 @@ from DIRAC.Core.DISET.RPCClient                            import RPCClient
 from DIRAC.Core.Utilities.List                             import fromChar
 
 # VMDIRAC
-from VMDIRAC.Resources.Cloud.CloudEndpointFactory          import CloudEndpointFactory
-from VMDIRAC.WorkloadManagementSystem.Agent.ConfigHelper   import findGenericCloudCredentials, \
+from VMDIRAC.Resources.Cloud.EndpointFactory               import EndpointFactory
+from VMDIRAC.Resources.Cloud.ConfigHelper                  import findGenericCloudCredentials, \
                                                                   getImages, \
                                                                   getPilotBootstrapParameters
 from VMDIRAC.WorkloadManagementSystem.Client.ServerUtils   import virtualMachineDB
@@ -162,9 +162,9 @@ class CloudDirector( AgentModule ):
     """
 
     self.imageDict = {}
-    ceFactory = CloudEndpointFactory()
+    ceFactory = EndpointFactory()
 
-    result = getPilotBootstrapParameters( vo = self.vo )
+    result = getPilotBootstrapParameters( vo = self.vo, runningPod = self.runningPod )
     if not result['OK']:
       return result
     opParameters = result['Value']

--- a/VMDIRAC/WorkloadManagementSystem/Agent/CloudDirector.py
+++ b/VMDIRAC/WorkloadManagementSystem/Agent/CloudDirector.py
@@ -419,7 +419,12 @@ class CloudDirector( AgentModule ):
       self.log.verbose( '%d job(s) from %d task queue(s) are eligible for %s queue' % (totalTQJobs, len( tqIDList ), image) )
 
       # Get the number of already instantiated VMs for these task queues
-      totalWaitingVMs = totalVMs
+      totalWaitingVMs = 0
+      result = virtualMachineDB.getInstanceCounters( 'Status', { 'Endpoint': endpoint } )
+      if result['OK']:
+        for status in result['Value']:
+          if status in [ 'New', 'Submitted' ]:
+            totalWaitingVMs += result['Value'][status]
       if totalWaitingVMs >= totalTQJobs:
         self.log.verbose( "%d VMs already for all the available jobs" % totalWaitingVMs )
 

--- a/VMDIRAC/WorkloadManagementSystem/Service/VirtualMachineManagerHandler.py
+++ b/VMDIRAC/WorkloadManagementSystem/Service/VirtualMachineManagerHandler.py
@@ -18,17 +18,17 @@ import os
 import commands
 
 # DIRAC
-from DIRAC                                               import gConfig, gLogger, S_ERROR, S_OK
-from DIRAC.Core.DISET.RequestHandler                     import RequestHandler
-from DIRAC.Core.Utilities.ThreadScheduler                import gThreadScheduler
-from DIRAC.ConfigurationSystem.Client.Helpers.Operations import Operations
+from DIRAC                                                import gConfig, gLogger, S_ERROR, S_OK
+from DIRAC.Core.DISET.RequestHandler                      import RequestHandler
+from DIRAC.Core.Utilities.ThreadScheduler                 import gThreadScheduler
+from DIRAC.ConfigurationSystem.Client.Helpers.Operations  import Operations
 
 # VMDIRAC
 from VMDIRAC.WorkloadManagementSystem.DB.VirtualMachineDB import VirtualMachineDB
-from VMDIRAC.Security import VmProperties
-from VMDIRAC.Resources.Cloud.Utilities import getVMImageConfig, STATE_MAP
-from VMDIRAC.Resources.Cloud.CloudEndpointFactory import CloudEndpointFactory
-from VMDIRAC.WorkloadManagementSystem.Agent.ConfigHelper import getImages
+from VMDIRAC.Security                                     import VmProperties
+from VMDIRAC.Resources.Cloud.Utilities                    import STATE_MAP
+from VMDIRAC.Resources.Cloud.ConfigHelper                 import getVMImageConfig, getImages
+from VMDIRAC.Resources.Cloud.EndpointFactory              import EndpointFactory
 
 __RCSID__ = '$Id$'
 
@@ -77,7 +77,7 @@ def getCEInstances( siteList = None, ceList = None, vo = None ):
   ceList = []
   for site in imageDict:
     for ce in imageDict[site]:
-      result = CloudEndpointFactory().getCE( site, ce )
+      result = EndpointFactory().getCE( site, ce )
       if not result['OK']:
         continue
       ceList.append( ( site, ce, result['Value'] ) )
@@ -119,7 +119,7 @@ def stopInstance( site, endpoint, nodeID ):
   if not result[ 'OK' ]:
     return result
   ceParams = result['Value']
-  ceFactory = CloudEndpointFactory()
+  ceFactory = EndpointFactory()
   result = ceFactory.getCEObject( parameters = ceParams )
   if not result['OK']:
     return result
@@ -129,7 +129,7 @@ def stopInstance( site, endpoint, nodeID ):
   return result
 
 
-def createCloudEndpoint( uniqueID ):
+def createEndpoint( uniqueID ):
 
   result = gVirtualMachineDB.getEndpointFromInstance( uniqueID )
   if not result[ 'OK' ]:
@@ -140,7 +140,7 @@ def createCloudEndpoint( uniqueID ):
   if not result[ 'OK' ]:
     return result
   ceParams = result['Value']
-  ceFactory = CloudEndpointFactory()
+  ceFactory = EndpointFactory()
   result = ceFactory.getCEObject( parameters = ceParams )
   return result
 
@@ -161,9 +161,9 @@ def haltInstances( vmList ):
       continue
     uniqueID = result [ 'Value' ]
 
-    result = createCloudEndpoint( uniqueID )
+    result = createEndpoint( uniqueID )
     if not result['OK']:
-      gLogger.error( 'haltInstances: on createCloudEndpoint call: %s' % result['Message'] )
+      gLogger.error( 'haltInstances: on createEndpoint call: %s' % result['Message'] )
       continue
 
     endpoint = result [ 'Value' ]


### PR DESCRIPTION
1. Add EC2 and rOCCI endpoint. EC2 use boto3 SDK and rOCCI use occi command
2. createUserDataScript is moved to the Endpoint base class
3. Fix a bug in CloudDirector when scheduling with more than one sites

The current CS structure for different endpoint type:
1. OpenStack (libcloud):
   
   ```
   CLOUD.IHEP-OPENSTACK.cn
   {
     Cloud
     {
       vmdirac01.ihep.ac.cn
       {
         CEType = Cloud
         Provider = OpenStack
         User = xxxxxxxx
         Password = xxxxxxxx
         ex_security_groups = default
         ex_force_auth_url = http://202.122.35.254:5000/v2.0/tokens
         ex_tenant_name = dirac
         ex_force_auth_version = 2.0_password
         ex_force_service_region = regionOne
         CVMFSProxy = http://202.122.33.53:3128
         HostCert = /opt/dirac/VMcertkey/servercert.pem
         HostKey = /opt/dirac/VMcertkey/serverkey.pem
         MaxInstances = 10
         Images
         {
           SL6-micro
           {
             ImageName = sl65-full
             FlavorName = m1.micro
           }
         }
       }
     }
   }
   ```
2. OpenNebula (rOCCI), FlavorName is optional because it is already included in the image (template in OpenNebula)
   Note: There could be more than one image with the same ImageName in OpenNebula (rOCCI), while ImageID is unique.
   
   ```
   CLOUD.IHEP-OPENNEBULA.cn
   {
     Cloud
     {
       vmdirac03.ihep.ac.cn
       {
         CEType = Rocci
         EndpointUrl = https://vmdirac03.ihep.ac.cn:11443
         Auth = basic
         User = xxxxxxxx
         Password = xxxxxxxx
         CVMFSProxy = http://202.122.33.53:3128
         HostCert = /opt/dirac/VMcertkey/servercert.pem
         HostKey = /opt/dirac/VMcertkey/serverkey.pem
         MaxInstances = 30
         Images
         {
           SL6-full
           {
             ImageID = uuid_sl65_boss_juno_49
           }
           SL7-small
           {
             ImageName = SL7-new
             FlavorName = small
           }
         }
       }
     }
   }
   ```
3. AWS (EC2)
   
   ```
   CLOUD.AWS.cn
   {
     Name = aws
     CE = CEnouse
     Cloud
     {
       cn-north-1
       {
         CEType = EC2
         RegionName = cn-north-1
         AccessKey = xxxxxxxx
         SecretKey = xxxxxxxx
         KeyName = ihep-admin
         CVMFSProxy = http://172.31.12.181:3128
         HostCert = /opt/dirac/VMcertkey/servercert.pem
         HostKey = /opt/dirac/VMcertkey/serverkey.pem
         MaxInstances = 2
         Images
         {
           SL6-full
           {
             ImageName = sl65-full
             FlavorName = t2.micro
           }
           SL7-c4large
           {
             ImageID = ami-23a9d857
             FlavorName = c4.large
             VO = bes
           }
         }
       }
     }
   }
   ```
