### PR TITLE
Add multicore support for VMDIRAC 2.0

### DIFF
--- a/VMDIRAC/Resources/Cloud/CloudEndpoint.py
+++ b/VMDIRAC/Resources/Cloud/CloudEndpoint.py
@@ -290,6 +290,9 @@ class CloudEndpoint( Endpoint ):
     if 'keyname' in self.parameters:
       createNodeDict['ex_keyname'] = self.parameters['keyname']
 
+    if 'availability_zone' in self.parameters:
+      createNodeDict['ex_availability_zone'] = self.parameters['availability_zone']
+
     # Create the VM instance now
     try:
       vmNode = self.__driver.create_node( **createNodeDict )

--- a/VMDIRAC/Resources/Cloud/Endpoint.py
+++ b/VMDIRAC/Resources/Cloud/Endpoint.py
@@ -48,8 +48,11 @@ class Endpoint( object ):
                       'running-pod': self.parameters['RunningPod'],
                       'cvmfs-proxy': self.parameters.get( 'CVMFSProxy', 'None' ),
                       'cs-servers': ','.join( self.parameters.get( 'CSServers', [] ) ),
-                      'release-version': self.parameters['Version'] ,
-                      'release-project': self.parameters['Project'] ,
+                      'number-of-processors': self.parameters.get( 'NumberOfProcessors', 1 ),
+                      'whole-node': self.parameters.get( 'WholeNode', True ),
+                      'required-tag': self.parameters.get( 'RequiredTag', '' ),
+                      'release-version': self.parameters['Version'],
+                      'release-project': self.parameters['Project'],
                       'setup': self.parameters['Setup'] }
 
     bootstrapString = ''

--- a/VMDIRAC/WorkloadManagementSystem/Agent/CloudDirector.py
+++ b/VMDIRAC/WorkloadManagementSystem/Agent/CloudDirector.py
@@ -212,7 +212,7 @@ class CloudDirector( AgentModule ):
               self.imageDict[imageName]['ParametersDict'].setdefault( 'Tags', [] )
               self.imageDict[imageName]['ParametersDict']['Tags'] += processorsTags
 
-          ceWholeNode = ceDict.get( 'WholeNode', 'false' )
+          ceWholeNode = ceDict.get( 'WholeNode', 'true' )
           wholeNode = self.imageDict[imageName]['ParametersDict'].get( 'WholeNode', ceWholeNode )
           if wholeNode.lower() in ( 'yes', 'true' ):
             self.imageDict[imageName]['ParametersDict'].setdefault( 'Tags', [] )

--- a/VMDIRAC/WorkloadManagementSystem/Bootstrap/vm-bootstrap
+++ b/VMDIRAC/WorkloadManagementSystem/Bootstrap/vm-bootstrap
@@ -155,7 +155,7 @@ chmod +x $CONTEXTDIR/save-payload-logs
 
 echo "*/5 * * * * root $CONTEXTDIR/save-payload-logs 2>/dev/null" >/etc/cron.d/save-payload-logs
 
-export NUM_JOB_SLOTS=
+export NUM_JOB_SLOTS=1
 if [ "$MACHINEFEATURES" ]; then
   export NUM_JOB_SLOTS=`python -c "import urllib ; print urllib.urlopen('$MACHINEFEATURES/log_cores').read().strip()"`
 fi

--- a/VMDIRAC/WorkloadManagementSystem/Bootstrap/vm-bootstrap
+++ b/VMDIRAC/WorkloadManagementSystem/Bootstrap/vm-bootstrap
@@ -52,6 +52,15 @@ case $i in
     --cs-servers=*)
     CS_SERVERS="${i#*=}"
     ;;
+    --number-of-processors=*)
+    NUMBER_OF_PROCESSORS="${i#*=}"
+    ;;
+    --whole-node=*)
+    WHOLE_NODE="${i#*=}"
+    ;;
+    --required-tag=*)
+    REQUIRED_TAG="${i#*=}"
+    ;;
     *)
     # unknown option
     ;;
@@ -183,6 +192,7 @@ chmod +x $CONTEXTDIR/parse-jobagent-log
 date --utc +"%Y-%m-%d %H:%M:%S %Z Starting $NUM_JOB_SLOTS pilots"
 
 n=0
+NUM_JOB_SLOTS=1
 while [ $n -lt $NUM_JOB_SLOTS ]
 do
   nn=`printf '%02d' $n`

--- a/VMDIRAC/WorkloadManagementSystem/Bootstrap/vm-pilot
+++ b/VMDIRAC/WorkloadManagementSystem/Bootstrap/vm-pilot
@@ -99,4 +99,4 @@ python dirac-pilot.py \
  -o /Resources/Computing/CEDefaults/SubmitPool=$SUBMIT_POOL \
  -o /Resources/Computing/CEDefaults/VirtualOrganization=$VO \
  -o '/Systems/WorkloadManagement/Production/Agents/JobAgent/StopAfterFailedMatches=0' \
- -o '/Systems/WorkloadManagement/Production/Agents/JobAgent/CEType=InProcess'
+ -o '/Systems/WorkloadManagement/Production/Agents/JobAgent/CEType=Pool'

--- a/VMDIRAC/WorkloadManagementSystem/Bootstrap/vm-pilot
+++ b/VMDIRAC/WorkloadManagementSystem/Bootstrap/vm-pilot
@@ -47,6 +47,15 @@ case $i in
     --cs-servers=*)
     CS_SERVERS="${i#*=}"
     ;;
+    --number-of-processors=*)
+    NUMBER_OF_PROCESSORS="${i#*=}"
+    ;;
+    --whole-node=*)
+    WHOLE_NODE="${i#*=}"
+    ;;
+    --required-tag=*)
+    REQUIRED_TAG="${i#*=}"
+    ;;
     *)
     # unknown option
     ;;
@@ -82,6 +91,12 @@ export LCG_GFAL_INFOSYS=cclcgtopbdii01.in2p3.fr:2170,topbdii.grif.fr:2170
 
 cp $CONTEXTDIR/*.py .
 
+
+REQUIRED_TAG_ARGS=''
+if [ $REQUIRED_TAG ]; then
+  REQUIRED_TAG_ARGS="-o /AgentJobRequirements/RequiredTag=$REQUIRED_TAG"
+fi
+
 # Run the Pilot 2.0 script
 python dirac-pilot.py \
  --debug \
@@ -98,5 +113,8 @@ python dirac-pilot.py \
  --certLocation=/scratch/$USER/etc/grid-security \
  -o /Resources/Computing/CEDefaults/SubmitPool=$SUBMIT_POOL \
  -o /Resources/Computing/CEDefaults/VirtualOrganization=$VO \
+ -o /Resources/Computing/CEDefaults/NumberOfProcessors=$NUMBER_OF_PROCESSORS \
+ -o /Resources/Computing/CEDefaults/WholeNode=$WHOLE_NODE \
+ $REQUIRED_TAG_ARGS \
  -o '/Systems/WorkloadManagement/Production/Agents/JobAgent/StopAfterFailedMatches=0' \
  -o '/Systems/WorkloadManagement/Production/Agents/JobAgent/CEType=Pool'


### PR DESCRIPTION
1. Multicore support is added. The logic is similar to SiteDirector. There will be only one pilot for each VM.
2. There are 3 configs added for each image: NumberOfProcessors, WholeNode, RequiredTag. The default value for each config is

       NumberOfProcessors = 1
       WholeNode = true
       RequiredTag =

   These configs will be passed to the bootstrap script.

3. A new config for libcloud is added: "availability_zone".