### PR TITLE
Fix addPilotTQReferences for DIRAC v6r20

### DIFF
--- a/VMDIRAC/WorkloadManagementSystem/Agent/CloudDirector.py
+++ b/VMDIRAC/WorkloadManagementSystem/Agent/CloudDirector.py
@@ -533,7 +533,6 @@ class CloudDirector( AgentModule ):
                                                     '',
                                                     self.localhost,
                                                     'Cloud',
-                                                    '',
                                                     stampDict )
         if not result['OK']:
           self.log.error( 'Failed to insert pilots into the PilotAgentsDB' )


### PR DESCRIPTION
In DIRAC v6r20, the definition of addPilotTQReferences only have 8 parameters instead of 9 in old verson