### PR TITLE
Fix for VMDIRAC VirtualMachineDB.__init__

### DIFF
--- a/VMDIRAC/WorkloadManagementSystem/DB/VirtualMachineDB.py
+++ b/VMDIRAC/WorkloadManagementSystem/DB/VirtualMachineDB.py
@@ -135,7 +135,7 @@ class VirtualMachineDB( DB ):
 
   def __init__( self, maxQueueSize = 10 ):
 
-    DB.__init__( self, 'VirtualMachineDB', 'WorkloadManagement/VirtualMachineDB', maxQueueSize )
+    DB.__init__( self, 'VirtualMachineDB', 'WorkloadManagement/VirtualMachineDB' )
     if not self._MySQL__initialized:
       raise Exception( 'Can not connect to VirtualMachineDB, exiting...' )
 


### PR DESCRIPTION
Following this change https://github.com/DIRACGrid/DIRAC/commit/a4c32b552f307f0acc1383ac640dae4e84b9f11f
DB.\_\_init\_\_ should not be called with maxQueueSize, which would be interpreted as the debug flag, and creates VirtualMachineDB.debug.log

BEGINRELEASENOTES

* VMDIRAC:
FIX: maxQueueSize removed from DB.\_\_init\_\_ call: not to make VirtualMachineDB.debug.log

ENDRELEASENOTES
