### PR TITLE
OpenStack AppCred support and many other minor fixes

### DIFF
--- a/VMDIRAC/Resources/Cloud/KeystoneClient.py
+++ b/VMDIRAC/Resources/Cloud/KeystoneClient.py
@@ -151,6 +151,7 @@ class KeystoneClient():
     user = self.parameters.get('User')
     password = self.parameters.get('Password')
     appcred_file = self.parameters.get('Appcred')
+    authDict = {}
     authArgs = {}
     if user and password:
       authDict = {'auth': {"identity": {"methods": ["password"],

--- a/VMDIRAC/Resources/Cloud/KeystoneClient.py
+++ b/VMDIRAC/Resources/Cloud/KeystoneClient.py
@@ -33,6 +33,7 @@ class KeystoneClient():
     self.computeURL = None
     self.imageURL = None
     self.networkURL = None
+    self.caPath = self.parameters.get('CAPath', True)
 
     self.valid = False
     result = self.initialize()
@@ -104,9 +105,6 @@ class KeystoneClient():
       if self.project:
         authDict['auth']['tenantName'] = self.project
 
-      caPath = self.parameters.get('CAPath')
-      if caPath:
-        authArgs['verify'] = caPath
       if self.parameters.get('Proxy'):
         authArgs['cert'] = self.parameters.get('Proxy')
 
@@ -114,6 +112,7 @@ class KeystoneClient():
       result = requests.post("%s/tokens" % self.url,
                              headers={"Content-Type": "application/json"},
                              json=authDict,
+                             verify=self.caPath,
                              **authArgs)
     except Exception as exc:
       return S_ERROR('Exception getting keystone token: %s' % str(exc))
@@ -163,17 +162,11 @@ class KeystoneClient():
                                         }
                            }
                   }
-      caPath = self.parameters.get('CAPath')
-      if caPath:
-        authArgs['verify'] = caPath
     elif self.parameters.get('Auth') == "voms":
       authDict = {"auth": {"identity": {"methods": ["mapped"],
                                         "mapped": {'voms': True,
                                                    'identity_provider': 'egi.eu',
                                                    "protocol": 'mapped'}}}}
-      caPath = self.parameters.get('CAPath')
-      if caPath:
-        authArgs['verify'] = caPath
       if self.parameters.get('Proxy'):
         authArgs['cert'] = self.parameters.get('Proxy')
     elif appcred_file:
@@ -209,6 +202,7 @@ class KeystoneClient():
                                       "Accept": "application/json",
                                       },
                              json=authDict,
+                             verify=self.caPath,
                              **authArgs)
 
     except Exception as exc:
@@ -263,8 +257,8 @@ class KeystoneClient():
     try:
       result = requests.get("%s/tenants" % self.url,
                             headers={"Content-Type": "application/json",
-                                     "X-Auth-Token": self.token}
-                            )
+                                     "X-Auth-Token": self.token},
+                            verify=self.caPath)
     except Exception as exc:
       return S_ERROR('Failed to get keystone token: %s' % str(exc))
 

--- a/VMDIRAC/Resources/Cloud/KeystoneClient.py
+++ b/VMDIRAC/Resources/Cloud/KeystoneClient.py
@@ -179,13 +179,8 @@ class KeystoneClient():
       ac_id, ac_secret = auth_info.split(" ", 1)
       ac_fd.close()
       authDict = {'auth': {"identity": {"methods": ["application_credential"],
-                                        "application_credential":
-                                          {"id": ac_id,
-                                           "secret": ac_secret,
-                                          }
-                                        }
-                           }
-                  }
+                                        "application_credential": {"id": ac_id,
+                                                                   "secret": ac_secret}}}}
     # appcred includes the project scope binding in the credential itself
     if self.project and not appcred_file:
       authDict['auth']['scope'] = {"project": {"domain": {"name": domain},

--- a/VMDIRAC/Resources/Cloud/OpenStackEndpoint.py
+++ b/VMDIRAC/Resources/Cloud/OpenStackEndpoint.py
@@ -280,7 +280,7 @@ class OpenStackEndpoint(Endpoint):
 
     try:
       response = requests.get("%s/servers" % self.computeURL,
-                              headers={"X-Auth-Token": self.token}
+                              headers={"X-Auth-Token": self.token},
                               verify=self.caPath)
     except Exception as e:
       return S_ERROR('Cannot connect to ' + str(self.computeURL) + ' (' + str(e) + ')')

--- a/VMDIRAC/Resources/Cloud/OpenStackEndpoint.py
+++ b/VMDIRAC/Resources/Cloud/OpenStackEndpoint.py
@@ -223,6 +223,7 @@ class OpenStackEndpoint(Endpoint):
       if not networkID:
         self.log.warn("Failed to get ID of the network interface")
 
+
     self.parameters['VMUUID'] = instanceID
     self.parameters['VMType'] = self.parameters.get('CEType', 'OpenStack')
 
@@ -241,6 +242,11 @@ class OpenStackEndpoint(Endpoint):
     # Some cloud sites do not expose network service interface, but some do
     if networkID:
       requestDict["server"]["networks"] = [{"uuid": networkID}]
+
+    # Allow the use of pre-uploaded SSH keys
+    osSSHKey = self.parameters.get('OSKeyName')
+    if osSSHKey:
+      requestDict["server"]["key_name"] = osSSHKey
 
     # print "AT >>> user data", userDataCrude
     # print "AT >>> requestDict", requestDict

--- a/VMDIRAC/Resources/Cloud/OpenStackEndpoint.py
+++ b/VMDIRAC/Resources/Cloud/OpenStackEndpoint.py
@@ -51,6 +51,7 @@ class OpenStackEndpoint(Endpoint):
 
   def initialize(self):
 
+    self.caPath = self.parameters.get('CAPath', True)
     self.network = self.parameters.get("Network")
     self.project = self.parameters.get("Project")
     keyStoneURL = self.parameters.get("AuthURL")
@@ -89,7 +90,8 @@ class OpenStackEndpoint(Endpoint):
     url = "%s/flavors/detail" % self.computeURL
     self.log.verbose("Getting flavors details on %s" % url)
 
-    result = requests.get(url, headers={"X-Auth-Token": self.token})
+    result = requests.get(url, headers={"X-Auth-Token": self.token},
+                               verify=self.caPath)
 
     output = json.loads(result.text)
     for flavor in output['flavors']:
@@ -105,7 +107,8 @@ class OpenStackEndpoint(Endpoint):
       return S_ERROR('The endpoint object is not initialized')
 
     result = requests.get("%s/v2/images" % self.imageURL,
-                          headers={"X-Auth-Token": self.token})
+                          headers={"X-Auth-Token": self.token},
+                          verify=self.caPath)
 
     output = json.loads(result.text)
     for image in output['images']:
@@ -121,7 +124,8 @@ class OpenStackEndpoint(Endpoint):
     """
     try:
       result = requests.get("%s/v2.0/networks" % self.networkURL,
-                            headers={"X-Auth-Token": self.token})
+                            headers={"X-Auth-Token": self.token},
+                            verify=self.caPath)
       output = json.loads(result.text)
     except Exception as exc:
       return S_ERROR('Cannot get networks: %s' % str(exc))
@@ -245,7 +249,8 @@ class OpenStackEndpoint(Endpoint):
     try:
       result = requests.post("%s/servers" % self.computeURL,
                              json=requestDict,
-                             headers=headers)
+                             headers=headers,
+                             verify=self.caPath)
     except Exception as exc:
       return S_ERROR('Exception creating VM: %s' % str(exc))
 
@@ -269,7 +274,8 @@ class OpenStackEndpoint(Endpoint):
 
     try:
       response = requests.get("%s/servers" % self.computeURL,
-                              headers={"X-Auth-Token": self.token})
+                              headers={"X-Auth-Token": self.token}
+                              verify=self.caPath)
     except Exception as e:
       return S_ERROR('Cannot connect to ' + str(self.computeURL) + ' (' + str(e) + ')')
 
@@ -325,7 +331,8 @@ class OpenStackEndpoint(Endpoint):
 
     try:
       response = requests.delete("%s/servers/%s" % (self.computeURL, nodeID),
-                                 headers={"X-Auth-Token": self.token})
+                                 headers={"X-Auth-Token": self.token},
+                                 verify=self.caPath)
     except Exception as e:
       return S_ERROR('Cannot get node details for %s (' % nodeID + str(e) + ')')
 
@@ -350,7 +357,8 @@ class OpenStackEndpoint(Endpoint):
     # Get the port of my VM
     try:
       result = requests.get("%s/v2.0/ports" % self.networkURL,
-                            headers={"X-Auth-Token": self.token})
+                            headers={"X-Auth-Token": self.token},
+                            verify=self.caPath)
       output = json.loads(result.text)
       portID = None
       for port in output['ports']:
@@ -393,7 +401,8 @@ class OpenStackEndpoint(Endpoint):
     # Get an available floating IP
     try:
       result = requests.get("%s/v2.0/floatingips" % self.networkURL,
-                            headers={"X-Auth-Token": self.token})
+                            headers={"X-Auth-Token": self.token},
+                            verify=self.caPath)
       output = json.loads(result.text)
     except Exception as e:
       return S_ERROR('Cannot get floatingips')
@@ -413,7 +422,8 @@ class OpenStackEndpoint(Endpoint):
     try:
       result = requests.put("%s/v2.0/floatingips/%s" % (self.networkURL, fipID),
                             data=dataJson,
-                            headers={"X-Auth-Token": self.token})
+                            headers={"X-Auth-Token": self.token},
+                            verify=self.caPath)
     except Exception as e:
       return S_ERROR('Cannot assign floating IP')
 
@@ -433,7 +443,8 @@ class OpenStackEndpoint(Endpoint):
 
     try:
       response = requests.get("%s/servers/%s" % (self.computeURL, vmID),
-                              headers={"X-Auth-Token": self.token})
+                              headers={"X-Auth-Token": self.token},
+                              verify=self.caPath)
     except Exception as e:
       return S_ERROR('Cannot get node details for %s (' % vmID + str(e) + ')')
 
@@ -497,7 +508,8 @@ class OpenStackEndpoint(Endpoint):
       # Get an available floating IP
       try:
         result = requests.get("%s/v2.0/floatingips" % self.networkURL,
-                              headers={"X-Auth-Token": self.token})
+                              headers={"X-Auth-Token": self.token},
+                              verify=self.caPath)
         output = json.loads(result.text)
       except Exception as e:
         return S_ERROR('Cannot get floatingips')
@@ -517,7 +529,8 @@ class OpenStackEndpoint(Endpoint):
     try:
       result = requests.put("%s/v2.0/floatingips/%s" % (self.networkURL, fipID),
                             data=dataJson,
-                            headers={"X-Auth-Token": self.token})
+                            headers={"X-Auth-Token": self.token},
+                            verify=self.caPath)
     except Exception as exc:
       return S_ERROR('Cannot disassociate floating IP: %s' % str(exc))
 

--- a/VMDIRAC/Resources/Cloud/OpenStackEndpoint.py
+++ b/VMDIRAC/Resources/Cloud/OpenStackEndpoint.py
@@ -90,8 +90,9 @@ class OpenStackEndpoint(Endpoint):
     url = "%s/flavors/detail" % self.computeURL
     self.log.verbose("Getting flavors details on %s" % url)
 
-    result = requests.get(url, headers={"X-Auth-Token": self.token},
-                               verify=self.caPath)
+    result = requests.get(url,
+                          headers={"X-Auth-Token": self.token},
+                          verify=self.caPath)
 
     output = json.loads(result.text)
     for flavor in output['flavors']:

--- a/VMDIRAC/Resources/Cloud/Utilities.py
+++ b/VMDIRAC/Resources/Cloud/Utilities.py
@@ -51,6 +51,7 @@ def createPilotDataScript(vmParameters, bootstrapParameters):
                    'whole-node': parameters.get('WholeNode', True),
                    'required-tag': parameters.get('RequiredTag', ''),
                    'release-version': parameters.get('Version'),
+                   'lcgbundle-version': parameters.get('LCGBundleVersion', ''),
                    'release-project': parameters.get('Project'),
                    'setup': parameters.get('Setup')}
 

--- a/VMDIRAC/WorkloadManagementSystem/Agent/CloudDirector.py
+++ b/VMDIRAC/WorkloadManagementSystem/Agent/CloudDirector.py
@@ -229,8 +229,11 @@ class CloudDirector(AgentModule):
           ceVMTypeDict['CSServers'] = gConfig.getValue("/DIRAC/Configuration/Servers", [])
           ceVMTypeDict.update(self.vmTypeDict[vmTypeName]['ParametersDict'])
 
-          ceVMTypeDict['CAPath'] = gConfig.getValue('/DIRAC/Security/CAPath',
-                                                    "/opt/dirac/etc/grid-security/certificates/cas.pem")
+          # Allow a resource-specifc CAPath to be set (as some clouds have their own CAs)
+          # Otherwise fall back to the system-wide default(s)
+          if 'CAPath' not in ceVMTypeDict:
+            ceVMTypeDict['CAPath'] = gConfig.getValue('/DIRAC/Security/CAPath',
+                                                      "/opt/dirac/etc/grid-security/certificates/cas.pem")
 
           # Generate the CE object for the vmType or pick the already existing one
           # if the vmType definition did not change

--- a/VMDIRAC/WorkloadManagementSystem/Bootstrap/vm-bootstrap
+++ b/VMDIRAC/WorkloadManagementSystem/Bootstrap/vm-bootstrap
@@ -112,6 +112,9 @@ chmod ugo+rwxt /scratch
 mkdir -p /scratch/tmp
 chmod ugo+rwxt /scratch/tmp
 
+# DIRAC externals require boost-python
+yum -y install boost-python
+
 # Bootstrap CVMFS
 vm_cvmfs_bootstrap
 

--- a/VMDIRAC/WorkloadManagementSystem/Bootstrap/vm-bootstrap-functions
+++ b/VMDIRAC/WorkloadManagementSystem/Bootstrap/vm-bootstrap-functions
@@ -48,6 +48,10 @@ vm_mount_scratch_disk() {
     # Xen virtual disk device
     mkfs -q -t ext4 /dev/xvdb
     mount /dev/xvdb /scratch
+  elif [ -b /dev/sda1 ] ; then
+    # No ephemeral disk, only a root partition without virtio dirver
+    # Nothing else to do, /scratch will just live in root dir
+    echo "No extra disk to mount, making /scratch right in the root partition"
   else
     date --utc +'%Y-%m-%d %H:%M:%S %Z vm-bootstrap Missing vda/vdb/hdb/sdb/xvdb block device for /scratch'
     echo "500 Missing vdb/hdb/sdb block device for /scratch" > /etc/joboutputs/shutdown_message
@@ -56,10 +60,11 @@ vm_mount_scratch_disk() {
   fi
 
   # We rely on the hypervisor's disk I/O scheduling
-  echo 'none' > /sys/block/vda/queue/scheduler
-  if [ -b /dev/vdb ] ; then
-    echo 'none' > /sys/block/vdb/queue/scheduler
-  fi
+  for DSK in vda vdb; do
+    if [ -b /dev/${DSK} ] ; then
+      echo 'none' > /sys/block/${DSK}/queue/scheduler
+    fi
+  done
 }
 
 vm_disable_mail() {
@@ -121,8 +126,9 @@ vm_cvmfs_bootstrap() {
       chcon -Rv --type=cvmfs_cache_t /scratch/cvmfs-cache
     fi
     cvmfs_config setup
-    cvmfs_config chksetup
-    cvmfs_config probe
+    # These steps are slow and unnecessary
+    #cvmfs_config chksetup
+    #cvmfs_config probe
     export CVMFS=1
   else
     echo CVMFS is not available on this VM

--- a/VMDIRAC/WorkloadManagementSystem/Bootstrap/vm-monitor-agent
+++ b/VMDIRAC/WorkloadManagementSystem/Bootstrap/vm-monitor-agent
@@ -2,7 +2,7 @@
 
 mkdir -p /opt/dirac/runit/VirtualMachineMonitorAgent/log
 
-cat > /opt/dirac/runit/VirtualMachineMonitorAgent/run << EOF
+cat > /opt/dirac/runit/VirtualMachineMonitorAgent/run << "EOF"
 #!/bin/bash
 rcfile=/opt/dirac/bashrc
 [ -e $rcfile ] && source $rcfile
@@ -14,7 +14,7 @@ exec 2>&1
 exec python $DIRAC/DIRAC/Core/scripts/dirac-agent.py WorkloadManagement/VirtualMachineMonitorAgent < /dev/null
 EOF
 
-cat > /opt/dirac/runit/VirtualMachineMonitorAgent/log/run << EOF
+cat > /opt/dirac/runit/VirtualMachineMonitorAgent/log/run << "EOF"
 #!/bin/bash
 #
 rcfile=/vo/dirac/bashrc
@@ -23,7 +23,7 @@ rcfile=/vo/dirac/bashrc
 exec svlogd .
 EOF
 
-cat > /opt/dirac/runit/VirtualMachineMonitorAgent/log/config << EOF
+cat > /opt/dirac/runit/VirtualMachineMonitorAgent/log/config << "EOF"
 s10000000
 n20
 EOF

--- a/VMDIRAC/WorkloadManagementSystem/Bootstrap/vm-pilot
+++ b/VMDIRAC/WorkloadManagementSystem/Bootstrap/vm-pilot
@@ -101,7 +101,7 @@ if [ $REQUIRED_TAG ]; then
 fi
 
 LCG_VER_ARG=''
-if [ "x${LCG_VER}" -ne "x" ]; then
+if [ "x${LCG_VER}" != "x" ]; then
   LCG_VER_ARG="-g ${LCG_VER}"
 fi
 

--- a/VMDIRAC/WorkloadManagementSystem/Bootstrap/vm-pilot
+++ b/VMDIRAC/WorkloadManagementSystem/Bootstrap/vm-pilot
@@ -38,6 +38,9 @@ case $i in
     --release-version=*)
     VERSION="${i#*=}"
     ;;
+    --lcgbundle-version=*)
+    LCG_VER="${i#*=}"
+    ;;
     --release-project=*)
     PROJECT="${i#*=}"
     ;;
@@ -97,6 +100,11 @@ if [ $REQUIRED_TAG ]; then
   REQUIRED_TAG_ARGS="-o /AgentJobRequirements/RequiredTag=$REQUIRED_TAG"
 fi
 
+LCG_VER_ARG=''
+if [ "x${LCG_VER}" -ne "x" ]; then
+  LCG_VER_ARG="-g ${LCG_VER}"
+fi
+
 # Run the Pilot 2.0 script
 python dirac-pilot.py \
  --debug \
@@ -104,6 +112,7 @@ python dirac-pilot.py \
  -r $VERSION \
  -l $PROJECT \
  -e VMDIRAC \
+ ${LCG_VER_ARG} \
  --MaxCycles 10 \
  --configurationServer $CS_SERVERS \
  --Name "$CE_NAME" \


### PR DESCRIPTION
Hi,

We've been getting VMDIRAC working for GridPP/IRIS projects. This set of commits fix all of the minor issues we've seen in our environment; I don't think any of them should break backwards compatibility for other users (although it's possible the CAPath one might).

Regards,
Simon


BEGINRELEASENOTES
NEW: Add ApplicationCredential auth support for OpenStack/Keystone.
FIX: Use CAPath everywhere in OpenStack & Keystone requests calls.
CHANGE: Allow CAPath to be set on a per-resource basis.
NEW: Add an option to allow OpenStack pre-uploaded SSH key to be used.
FIX: Install python-boost in VM image so that data transfer commands work in installed environment.
NEW: Add LCGBundleVersion config parameter, to allow LCG bundle installation in VM.
FIX: Escape VMMonitor agent start-up scripts correctly.
FIX: Allow VM to run when root block device is "sda1" rather than more usual "vda1".
FIX: Speed up CVMFS install by skipping unnecessary steps.
ENDRELEASENOTES
