### PR TITLE
Allow nested containers

### DIFF
--- a/VMDIRAC/Resources/Cloud/cloudinit.template
+++ b/VMDIRAC/Resources/Cloud/cloudinit.template
@@ -161,6 +161,8 @@ packages:
  - singularity
 
 runcmd:
+ # Allow nested singularity
+ - [ sysctl, user.max_user_namespaces=150000 ]
  # Enable CVMFS
  - [ mkdir, -p, /mnt/cvmfs ]
  - [ cvmfs_config, setup ]


### PR DESCRIPTION
This patch enables user namespaces for instances using the cloudinit start-up method. This should allow normal user payloads to also use singularity while still maintaining the outer singularity for payload isolation.

BEGINRELEASENOTES
NEW: Allow user namespaces in cloudinit config.
ENDRELEASENOTES