### PR TITLE
VMMonitor: Consider JDLs in root location

### DIFF
--- a/VMDIRAC/WorkloadManagementSystem/Agent/VirtualMachineMonitorAgent.py
+++ b/VMDIRAC/WorkloadManagementSystem/Agent/VirtualMachineMonitorAgent.py
@@ -159,7 +159,8 @@ class VirtualMachineMonitorAgent(AgentModule):
     if not os.path.isdir(self.vmJobWrappersLocation):
       return 0
     self.log.info("VM job wrappers path: %s" % self.vmJobWrappersLocation)
-    jdlList = glob.glob(os.path.join(self.vmJobWrappersLocation, "*", "*.jdl"))
+    jdlList = glob.glob(os.path.join(self.vmJobWrappersLocation, "*.jdl"))
+    jdlList += glob.glob(os.path.join(self.vmJobWrappersLocation, "*", "*.jdl"))
     return len(jdlList)
 
   def execute(self):


### PR DESCRIPTION
Fixes #135 

The VM monitor originally only counted JDL files in subdirs of the search path. In the cloud-init/container mode, the JDLs are written to the top-level directory and then missed. This just adds a line to count JDL files in this top directory too.

BEGINRELEASENOTES
FIX: VMMonitor: Count JDLs in root dir as well as sub-dirs.
ENDRELEASENOTES
