### PR TITLE
Fix cloudinit monitor dirac-install options

### DIFF
--- a/VMDIRAC/Resources/Cloud/cloudinit.template
+++ b/VMDIRAC/Resources/Cloud/cloudinit.template
@@ -124,7 +124,7 @@ write_files:
        chmod +x dirac-install.py
      fi
 
-     python dirac-install.py -t server -r %(release-version)s -e VMDIRAC
+     python dirac-install.py -r %(release-version)s -e VMDIRAC
      mkdir -p etc/grid-security
      cp /root/hostkey.pem etc/grid-security/hostkey.pem
      chmod 600 etc/grid-security/hostkey.pem


### PR DESCRIPTION
dirac-install no longer supports or needs the -t option. This causes the monitor install to fail, resulting in instances getting swept away as broken after a few hours.

BEGINRELEASENOTES
FIX: Fix VM monitor install by removing -t option from dirac-install.
ENDRELEASENOTES
